### PR TITLE
Feat: Dodaj wskaźnik statusu ON/OFF do przełącznika GP Skills

### DIFF
--- a/gildie_polzawodowe.js
+++ b/gildie_polzawodowe.js
@@ -13,7 +13,7 @@ const semiGuildsData = [
           "wyczucie kierunku": 60,
           "znajomosc jezykow": 60,
           "magia zycia": 80,
-          "koncentracje": 60,
+          "koncentracja": 60,
           "koncentracja w walce": 60,
           "czarodziejstwo": 50,
           "mistycyzm": 80
@@ -35,7 +35,7 @@ const semiGuildsData = [
           "tarczownictwo": 60,
           "walke w szyku": 70,
           "magia zycia": 60,
-          "koncentracje": 50,
+          "koncentracja": 50,
           "koncentracja w walce": 70,
           "zaklinanie": 60
         }
@@ -47,7 +47,7 @@ const semiGuildsData = [
           "parowanie": 60,
           "walke w szyku": 70,
           "magia zycia": 60,
-          "koncentracje": 50,
+          "koncentracja": 50,
           "koncentracja w walce": 70,
           "zaklinanie": 60
         }
@@ -59,7 +59,7 @@ const semiGuildsData = [
           "uniki": 60,
           "walke w szyku": 70,
           "magia zycia": 60,
-          "koncentracje": 50,
+          "koncentracja": 50,
           "koncentracja w walce": 70,
           "zaklinanie": 60
         }
@@ -146,7 +146,7 @@ const semiGuildsData = [
         skills: {
           "znajomosc jezykow": 50,
           "magia zycia": 40,
-          "koncentracje": 60,
+          "koncentracja": 60,
           "koncentracja w walce": 40,
           "przemiane": 60,
           "mistycyzm": 60,
@@ -182,7 +182,7 @@ const semiGuildsData = [
           "znajomosc jezykow": 60,
           "skradanie sie": 60,
           "ukrywanie sie": 60,
-          "koncentracje": 60,
+          "koncentracja": 60,
           "magia runiczna": 80
         }
       },
@@ -196,7 +196,7 @@ const semiGuildsData = [
           "skradanie sie": 60,
           "ukrywanie sie": 60,
           "magia mroku": 80,
-          "koncentracje": 60,
+          "koncentracja": 60,
           "koncentracja w walce": 70,
           "magia runiczna": 60
         }
@@ -246,7 +246,7 @@ const semiGuildsData = [
           "magia powietrza": 46,
           "magia ziemi": 46,
           "magia wody": 81,
-          "koncentracje": 70,
+          "koncentracja": 70,
           "koncentracja w walce": 60,
           "czarodziejstwo": 40,
           "przemiane": 35,
@@ -264,7 +264,7 @@ const semiGuildsData = [
           "magia powietrza": 46,
           "magia ziemi": 81,
           "magia wody": 46,
-          "koncentracje": 70,
+          "koncentracja": 70,
           "koncentracja w walce": 60,
           "czarodziejstwo": 40,
           "przemiane": 35,
@@ -282,7 +282,7 @@ const semiGuildsData = [
           "magia powietrza": 81,
           "magia ziemi": 46,
           "magia wody": 46,
-          "koncentracje": 70,
+          "koncentracja": 70,
           "koncentracja w walce": 60,
           "czarodziejstwo": 40,
           "przemiane": 35,
@@ -300,7 +300,7 @@ const semiGuildsData = [
           "magia powietrza": 55,
           "magia ziemi": 55,
           "magia wody": 55,
-          "koncentracje": 70,
+          "koncentracja": 70,
           "koncentracja w walce": 60,
           "czarodziejstwo": 40,
           "przemiane": 35,
@@ -318,7 +318,7 @@ const semiGuildsData = [
           "magia powietrza": 46,
           "magia ziemi": 46,
           "magia wody": 46,
-          "koncentracje": 70,
+          "koncentracja": 70,
           "koncentracja w walce": 60,
           "czarodziejstwo": 40,
           "przemiane": 35,

--- a/gildie_zawodowe.js
+++ b/gildie_zawodowe.js
@@ -1,495 +1,495 @@
- // Guild Data Structure
-        const guildsData = [
+// Guild Data Structure
+const guildsData = [
+    {
+        name: "Szermierze",
+        code: "sz",
+        type: "zawodowa",
+        races: ["czlowiek", "elf", "niziolek", "kmaran", "gnom", "reptilion"],
+        paths: [
             {
-                name: "Szermierze",
-                code: "sz",
-                type: "zawodowa",
-                races: ["czlowiek", "elf", "niziolek", "kmaran", "gnom", "reptilion"],
-                paths: [
-                    {
-                        name: "fechmistrz",
-                        activePlayers: 4,
-                        specs: ["pchniecie szermierzy", "rozbrojenie szermierzy"],
-                        skills: {
-                            "miecze": 85,
-                            "sztylety": 91,
-                            "walka dwiema bronmi": 70,
-                            "parowanie": 70,
-                            "uniki": 70,
-                            "ocena przeciwnika": 70,
-                            "ocena obiektu": 60,
-                            "opieka nad zwierzetami": 50,
-                            "spostrzegawczosc": 60,
-                            "jezdziectwo": 50,
-                            "znajomosc jezykow": 50,
-                            "fechtunek": 100
-                        }
-                    },
-                    {
-                        name: "zaklinacz ostrzy",
-                        activePlayers: 0,
-                        specs: [],
-                        skills: {
-                            "miecze": 95,
-                            "maczugi": 95,
-                            "parowanie": 80,
-                            "uniki": 75,
-                            "ocena przeciwnika": 70,
-                            "ocena obiektu": 60,
-                            "opieka nad zwierzetami": 50,
-                            "spostrzegawczosc": 60,
-                            "jezdziectwo": 50,
-                            "znajomosc jezykow": 50,
-                            "koncentracje": 60,
-                            "koncentracja w walce": 70,
-                            "rozpraszanie": 80
-                        }
-                    }
-                ]
+                name: "fechmistrz",
+                activePlayers: 4,
+                specs: ["pchniecie szermierzy", "rozbrojenie szermierzy"],
+                skills: {
+                    "miecze": 85,
+                    "sztylety": 91,
+                    "walka dwiema bronmi": 70,
+                    "parowanie": 70,
+                    "uniki": 70,
+                    "ocena przeciwnika": 70,
+                    "ocena obiektu": 60,
+                    "opieka nad zwierzetami": 50,
+                    "spostrzegawczosc": 60,
+                    "jezdziectwo": 50,
+                    "znajomosc jezykow": 50,
+                    "fechtunek": 100
+                }
             },
             {
-                name: "Magowie Minas-Morgul",
-                code: "mm",
-                type: "zawodowa",
-                races: ["czlowiek", "elf", "krasnolud", "goblin", "reptilion", "ork", "kmaran", "gnom", "niziolek"],
-                paths: [
-                    {
-                        name: "mroczny wojownik",
-                        activePlayers: 1,
-                        specs: ["widmowe ciecie Morgulu"],
-                        skills: {
-                            "miecze": 90,
-                            "mloty": 90,
-                            "bronie drzewcowe": 90,
-                            "parowanie": 85,
-                            "uniki": 75,
-                            "ocena przeciwnika": 50,
-                            "ocena obiektu": 50,
-                            "opieka nad zwierzetami": 50,
-                            "wyczucie kierunku": 70,
-                            "spostrzegawczosc": 65,
-                            "jezdziectwo": 60,
-                            "znajomosc jezykow": 65,
-                            "niematerialne ciecie": 100
-                        }
-                    },
-                    {
-                        name: "mroczny kaplan",
-                        activePlayers: 2,
-                        specs: ["tchnienie Morgulu"],
-                        skills: {
-                            "sztylety": 70,
-                            "bicze": 70,
-                            "parowanie": 50,
-                            "uniki": 50,
-                            "ocena przeciwnika": 50,
-                            "ocena obiektu": 50,
-                            "opieka nad zwierzetami": 50,
-                            "wyczucie kierunku": 70,
-                            "spostrzegawczosc": 65,
-                            "jezdziectwo": 60,
-                            "znajomosc jezykow": 65,
-                            "magia mroku": 85,
-                            "koncentracje": 80,
-                            "koncentracja w walce": 80,
-                            "iluzje": 80
-                        }
-                    },
-                    {
-                        name: "rycerz morgulu",
-                        activePlayers: 8,
-                        specs: ["manewry Morgulu"],
-                        skills: {
-                            "sztylety": 80,
-                            "mloty": 80,
-                            "walka dwiema bronmi": 65,
-                            "parowanie": 65,
-                            "uniki": 65,
-                            "tarczownictwo": 65,
-                            "ocena przeciwnika": 50,
-                            "ocena obiektu": 50,
-                            "opieka nad zwierzetami": 50,
-                            "wyczucie kierunku": 70,
-                            "spostrzegawczosc": 65,
-                            "jezdziectwo": 60,
-                            "znajomosc jezykow": 65,
-                            "manewry bojowe": 100
-                        }
-                    }
-                ]
-            },
-            {
-                name: "Ludzie Piaskow",
-                code: "lp",
-                type: "zawodowa",
-                races: ["czlowiek", "elf", "krasnolud", "goblin", "reptilion", "ork", "kmaran", "gnom", "niziolek"],
-                paths: [
-                    {
-                        name: "krytyki",
-                        activePlayers: 0,
-                        specs: [],
-                        skills: {
-                            "szable": 90,
-                            "sztylety": 100,
-                            "walka dwiema bronmi": 60,
-                            "parowanie": 70,
-                            "uniki": 70,
-                            "wyczucie kierunku": 55,
-                            "tropienie": 60,
-                            "spostrzegawczosc": 80,
-                            "skradanie sie": 50,
-                            "ukrywanie sie": 50,
-                            "wyczucie slabosci": 60,
-                            "rzut piaskiem": 100,
-                            "ciecie": 100
-                        }
-                    },
-                    {
-                        name: "default",
-                        activePlayers: 2,
-                        specs: ["sypniecie piaskiem", "dzgniecie"],
-                        skills: {
-                            "szable": 90,
-                            "sztylety": 100,
-                            "walka dwiema bronmi": 60,
-                            "parowanie": 70,
-                            "uniki": 70,
-                            "wyczucie kierunku": 55,
-                            "tropienie": 60,
-                            "spostrzegawczosc": 80,
-                            "skradanie sie": 50,
-                            "ukrywanie sie": 50,
-                            "rzut piaskiem": 100,
-                            "ciecie": 100
-                        }
-                    }
-                ]
-            },
-            {
-                name: "Lesne Legendy",
-                code: "ll",
-                type: "zawodowa",
-                races: ["goblin"],
-                paths: [
-                    {
-                        name: "default",
-                        activePlayers: 4,
-                        specs: ["chlasniecie toporem"],
-                        skills: {
-                            "topory": 80,
-                            "maczugi": 80,
-                            "walka dwiema bronmi": 70,
-                            "parowanie": 60,
-                            "uniki": 70,
-                            "ocena przeciwnika": 50,
-                            "ocena obiektu": 50,
-                            "szacowanie": 50,
-                            "wyczucie kierunku": 61,
-                            "tropienie": 60,
-                            "spostrzegawczosc": 60,
-                            "skradanie sie": 60,
-                            "ukrywanie sie": 70,
-                            "regeneracje": 100,
-                            "odpornosc": 100,
-                            "chlasniecie": 100
-                        }
-                    }
-                ]
-            },
-            {
-                name: "Lesne Duchy",
-                code: "ld",
-                type: "zawodowa",
-                races: ["elf"],
-                paths: [
-                    {
-                        name: "miecz",
-                        activePlayers: 3,
-                        specs: ["taniec broni"],
-                        skills: {
-                            "miecze": 90,
-                            "sztylety": 90,
-                            "walka dwiema bronmi": 60,
-                            "parowanie": 60,
-                            "uniki": 70,
-                            "wyczucie kierunku": 70,
-                            "tropienie": 70,
-                            "spostrzegawczosc": 80,
-                            "skradanie sie": 80,
-                            "ukrywanie sie": 80,
-                            "taniec broni": 100
-                        }
-                    },
-                    {
-                        name: "wlocznia",
-                        activePlayers: 0,
-                        specs: ["taniec broni"],
-                        skills: {
-                            "sztylety": 90,
-                            "wlocznie": 90,
-                            "parowanie": 90,
-                            "uniki": 80,
-                            "wyczucie kierunku": 70,
-                            "tropienie": 70,
-                            "spostrzegawczosc": 80,
-                            "skradanie sie": 80,
-                            "ukrywanie sie": 80,
-                            "taniec broni": 100
-                        }
-                    }
-                ]
-            },
-            {
-                name: "Khazad-Dum",
-                code: "kd",
-                type: "zawodowa",
-                races: ["krasnolud", "gnom"],
-                paths: [
-                    {
-                        name: "default",
-                        activePlayers: 2,
-                        specs: ["krasnoludzka riposta"],
-                        skills: {
-                            "topory": 85,
-                            "mloty": 85,
-                            "walka w ciemnosci": 70,
-                            "parowanie": 60,
-                            "tarczownictwo": 80,
-                            "walke w szyku": 55,
-                            "ocena przeciwnika": 60,
-                            "ocena obiektu": 60,
-                            "plywanie": 75,
-                            "wspinaczke": 80,
-                            "wyczucie kierunku": 70,
-                            "tropienie": 75,
-                            "spostrzegawczosc": 70,
-                            "znajomosc jezykow": 60,
-                            "riposta": 100
-                        }
-                    }
-                ]
-            },
-            {
-                name: "Gwardia Katana",
-                code: "gk",
-                type: "zawodowa",
-                races: ["ork", "czlowiek"],
-                paths: [
-                    {
-                        name: "default",
-                        activePlayers: 2,
-                        specs: ["uderzenie tarcza", "ciecie szabla"],
-                        skills: {
-                            "szable": 95,
-                            "bronie lancuchowe": 95,
-                            "parowanie": 70,
-                            "tarczownictwo": 75,
-                            "walke w szyku": 70,
-                            "ocena przeciwnika": 50,
-                            "ocena obiektu": 50,
-                            "szacowanie": 50,
-                            "plywanie": 60,
-                            "wspinaczke": 80,
-                            "wyczucie kierunku": 50,
-                            "tropienie": 60,
-                            "spostrzegawczosc": 60,
-                            "uderzenie tarcza": 100,
-                            "gwardyjski cios": 100
-                        }
-                    }
-                ]
-            },
-            {
-                name: "Druidzki Krag",
-                code: "dr",
-                type: "zawodowa",
-                races: ["czlowiek", "elf", "krasnolud", "goblin", "reptilion", "kmaran", "gnom", "niziolek"],
-                paths: [
-                    {
-                        name: "zmiennoksztaltny",
-                        activePlayers: 7,
-                        specs: ["zwinny cios"],
-                        skills: {
-                            "walka bez broni": 80,
-                            "uniki": 75,
-                            "ocena przeciwnika": 55,
-                            "opieka nad zwierzetami": 60,
-                            "wyczucie kierunku": 60,
-                            "tropienie": 50,
-                            "spostrzegawczosc": 60,
-                            "jezdziectwo": 50,
-                            "skradanie sie": 40,
-                            "ukrywanie sie": 40,
-                            "zwinny cios": 100,
-                            "koncentracje": 50,
-                            "koncentracja w walce": 50,
-                            "przemiane": 80,
-                            "przywolywanie": 40
-                        }
-                    },
-                    {
-                        name: "przywolywacz",
-                        activePlayers: 7,
-                        specs: [],
-                        skills: {
-                            "bronie drzewcowe": 60,
-                            "wlocznie": 60,
-                            "parowanie": 70,
-                            "ocena przeciwnika": 55,
-                            "opieka nad zwierzetami": 60,
-                            "wyczucie kierunku": 60,
-                            "tropienie": 50,
-                            "spostrzegawczosc": 60,
-                            "jezdziectwo": 50,
-                            "skradanie sie": 40,
-                            "ukrywanie sie": 40,
-                            "koncentracje": 70,
-                            "koncentracja w walce": 50,
-                            "iluzje": 70,
-                            "przywolywanie": 80
-                        }
-                    }
-                ]
-            },
-			{
-                name: "Armia Saurona",
-                code: "ar",
-                type: "zawodowa",
-                races: ["ork", "goblin", "reptilion"],
-                paths: [
-                    {
-                        name: "default",
-                        activePlayers: 7,
-                        specs: ["crush"],
-                        skills: {
-                            "miecze": 85,
-                            "topory": 85,
-                            "maczugi": 85,
-                            "mloty": 85,
-                            "parowanie": 75,
-                            "tarczownictwo": 75,
-                            "walke w szyku": 65,
-                            "ocena przeciwnika": 70,
-                            "wspinaczke ": 70,
-                            "wyczucie kierunku": 70,
-                            "spostrzegawczosc": 75,
-                            "walke tarcza": 100
-                        }
-                    },
-                    
-                ]
-            },
-            {
-                name: "Bractwo Zywiolow",
-                code: "bz_o",
-                type: "zawodowa",
-                races: ["czlowiek", "elf", "krasnolud", "reptilion", "kmaran", "gnom", "niziolek"],
-                paths: [
-                    {
-                        name: "occ_magia ognia",
-                        activePlayers: 2,
-                        specs: [],
-                        skills: {
-                            "ocena obiektu": 40,
-                            "szacowanie": 40,
-                            "znajomosc jezykow": 55,
-                            "magia ognia": 99,
-                            "magia powietrza": 67,
-                            "magia ziemi": 67,
-                            "magia wody": 67,
-                            "koncentracje": 90,
-                            "koncentracja w walce": 70,
-                            "magia runiczna": 40,
-                            "czarodziejstwo": 40,
-                            "przemiane": 40,
-                            "zaklinanie": 35,
-                            "rozpraszanie": 40
-                        }
-                    },
-                    {
-                        name: "occ_magia powietrza",
-                        activePlayers: 1,
-                        specs: [],
-                        skills: {
-                            "ocena obiektu": 40,
-                            "szacowanie": 40,
-                            "znajomosc jezykow": 55,
-                            "magia ognia": 67,
-                            "magia powietrza": 99,
-                            "magia ziemi": 67,
-                            "magia wody": 67,
-                            "koncentracje": 90,
-                            "koncentracja w walce": 70,
-                            "magia runiczna": 40,
-                            "czarodziejstwo": 40,
-                            "przemiane": 40,
-                            "zaklinanie": 35,
-                            "rozpraszanie": 40
-                        }
-                    },
-                    {
-                        name: "occ_magia wody",
-                        activePlayers: 1,
-                        specs: [],
-                        skills: {
-                            "ocena obiektu": 40,
-                            "szacowanie": 40,
-                            "znajomosc jezykow": 55,
-                            "magia ognia": 67,
-                            "magia powietrza": 67,
-                            "magia ziemi": 67,
-                            "magia wody": 99,
-                            "koncentracje": 90,
-                            "koncentracja w walce": 70,
-                            "magia runiczna": 40,
-                            "czarodziejstwo": 40,
-                            "przemiane": 40,
-                            "zaklinanie": 35,
-                            "rozpraszanie": 40
-                        }
-                    },
-                    {
-                        name: "occ_general",
-                        activePlayers: 1,
-                        specs: [],
-                        skills: {
-                            "ocena obiektu": 40,
-                            "szacowanie": 40,
-                            "znajomosc jezykow": 55,
-                            "magia ognia": 75,
-                            "magia powietrza": 75,
-                            "magia ziemi": 75,
-                            "magia wody": 75,
-                            "koncentracje": 90,
-                            "koncentracja w walce": 70,
-                            "magia runiczna": 40,
-                            "czarodziejstwo": 40,
-                            "przemiane": 40,
-                            "zaklinanie": 35,
-                            "rozpraszanie": 40
-                        }
-                    },
-                    {
-                        name: "occ_magia ziemi",
-                        activePlayers: 1,
-                        specs: [],
-                        skills: {
-                            "ocena obiektu": 40,
-                            "szacowanie": 40,
-                            "znajomosc jezykow": 55,
-                            "magia ognia": 67,
-                            "magia powietrza": 67,
-                            "magia ziemi": 99,
-                            "magia wody": 67,
-                            "koncentracje": 90,
-                            "koncentracja w walce": 70,
-                            "magia runiczna": 40,
-                            "czarodziejstwo": 40,
-                            "przemiane": 40,
-                            "zaklinanie": 35,
-                            "rozpraszanie": 40
-                        }
-                    }
-                ]
+                name: "zaklinacz ostrzy",
+                activePlayers: 0,
+                specs: [],
+                skills: {
+                    "miecze": 95,
+                    "maczugi": 95,
+                    "parowanie": 80,
+                    "uniki": 75,
+                    "ocena przeciwnika": 70,
+                    "ocena obiektu": 60,
+                    "opieka nad zwierzetami": 50,
+                    "spostrzegawczosc": 60,
+                    "jezdziectwo": 50,
+                    "znajomosc jezykow": 50,
+                    "koncentracja": 60,
+                    "koncentracja w walce": 70,
+                    "rozpraszanie": 80
+                }
             }
-        ];
+        ]
+    },
+    {
+        name: "Magowie Minas-Morgul",
+        code: "mm",
+        type: "zawodowa",
+        races: ["czlowiek", "elf", "krasnolud", "goblin", "reptilion", "ork", "kmaran", "gnom", "niziolek"],
+        paths: [
+            {
+                name: "mroczny wojownik",
+                activePlayers: 1,
+                specs: ["widmowe ciecie Morgulu"],
+                skills: {
+                    "miecze": 90,
+                    "mloty": 90,
+                    "bronie drzewcowe": 90,
+                    "parowanie": 85,
+                    "uniki": 75,
+                    "ocena przeciwnika": 50,
+                    "ocena obiektu": 50,
+                    "opieka nad zwierzetami": 50,
+                    "wyczucie kierunku": 70,
+                    "spostrzegawczosc": 65,
+                    "jezdziectwo": 60,
+                    "znajomosc jezykow": 65,
+                    "niematerialne ciecie": 100
+                }
+            },
+            {
+                name: "mroczny kaplan",
+                activePlayers: 2,
+                specs: ["tchnienie Morgulu"],
+                skills: {
+                    "sztylety": 70,
+                    "bicze": 70,
+                    "parowanie": 50,
+                    "uniki": 50,
+                    "ocena przeciwnika": 50,
+                    "ocena obiektu": 50,
+                    "opieka nad zwierzetami": 50,
+                    "wyczucie kierunku": 70,
+                    "spostrzegawczosc": 65,
+                    "jezdziectwo": 60,
+                    "znajomosc jezykow": 65,
+                    "magia mroku": 85,
+                    "koncentracja": 80,
+                    "koncentracja w walce": 80,
+                    "iluzja": 80
+                }
+            },
+            {
+                name: "rycerz morgulu",
+                activePlayers: 8,
+                specs: ["manewry Morgulu"],
+                skills: {
+                    "sztylety": 80,
+                    "mloty": 80,
+                    "walka dwiema bronmi": 65,
+                    "parowanie": 65,
+                    "uniki": 65,
+                    "tarczownictwo": 65,
+                    "ocena przeciwnika": 50,
+                    "ocena obiektu": 50,
+                    "opieka nad zwierzetami": 50,
+                    "wyczucie kierunku": 70,
+                    "spostrzegawczosc": 65,
+                    "jezdziectwo": 60,
+                    "znajomosc jezykow": 65,
+                    "manewry bojowe": 100
+                }
+            }
+        ]
+    },
+    {
+        name: "Ludzie Piaskow",
+        code: "lp",
+        type: "zawodowa",
+        races: ["czlowiek", "elf", "krasnolud", "goblin", "reptilion", "ork", "kmaran", "gnom", "niziolek"],
+        paths: [
+            {
+                name: "krytyki",
+                activePlayers: 0,
+                specs: [],
+                skills: {
+                    "szable": 90,
+                    "sztylety": 100,
+                    "walka dwiema bronmi": 60,
+                    "parowanie": 70,
+                    "uniki": 70,
+                    "wyczucie kierunku": 55,
+                    "tropienie": 60,
+                    "spostrzegawczosc": 80,
+                    "skradanie sie": 50,
+                    "ukrywanie sie": 50,
+                    "wyczucie slabosci": 60,
+                    "rzut piaskiem": 100,
+                    "ciecie": 100
+                }
+            },
+            {
+                name: "default",
+                activePlayers: 2,
+                specs: ["sypniecie piaskiem", "dzgniecie"],
+                skills: {
+                    "szable": 90,
+                    "sztylety": 100,
+                    "walka dwiema bronmi": 60,
+                    "parowanie": 70,
+                    "uniki": 70,
+                    "wyczucie kierunku": 55,
+                    "tropienie": 60,
+                    "spostrzegawczosc": 80,
+                    "skradanie sie": 50,
+                    "ukrywanie sie": 50,
+                    "rzut piaskiem": 100,
+                    "ciecie": 100
+                }
+            }
+        ]
+    },
+    {
+        name: "Lesne Legendy",
+        code: "ll",
+        type: "zawodowa",
+        races: ["goblin"],
+        paths: [
+            {
+                name: "default",
+                activePlayers: 4,
+                specs: ["chlasniecie toporem"],
+                skills: {
+                    "topory": 80,
+                    "maczugi": 80,
+                    "walka dwiema bronmi": 70,
+                    "parowanie": 60,
+                    "uniki": 70,
+                    "ocena przeciwnika": 50,
+                    "ocena obiektu": 50,
+                    "szacowanie": 50,
+                    "wyczucie kierunku": 61,
+                    "tropienie": 60,
+                    "spostrzegawczosc": 60,
+                    "skradanie sie": 60,
+                    "ukrywanie sie": 70,
+                    "regeneracje": 100,
+                    "odpornosc": 100,
+                    "chlasniecie": 100
+                }
+            }
+        ]
+    },
+    {
+        name: "Lesne Duchy",
+        code: "ld",
+        type: "zawodowa",
+        races: ["elf"],
+        paths: [
+            {
+                name: "miecz",
+                activePlayers: 3,
+                specs: ["taniec broni"],
+                skills: {
+                    "miecze": 90,
+                    "sztylety": 90,
+                    "walka dwiema bronmi": 60,
+                    "parowanie": 60,
+                    "uniki": 70,
+                    "wyczucie kierunku": 70,
+                    "tropienie": 70,
+                    "spostrzegawczosc": 80,
+                    "skradanie sie": 80,
+                    "ukrywanie sie": 80,
+                    "taniec broni": 100
+                }
+            },
+            {
+                name: "wlocznia",
+                activePlayers: 0,
+                specs: ["taniec broni"],
+                skills: {
+                    "sztylety": 90,
+                    "wlocznie": 90,
+                    "parowanie": 90,
+                    "uniki": 80,
+                    "wyczucie kierunku": 70,
+                    "tropienie": 70,
+                    "spostrzegawczosc": 80,
+                    "skradanie sie": 80,
+                    "ukrywanie sie": 80,
+                    "taniec broni": 100
+                }
+            }
+        ]
+    },
+    {
+        name: "Khazad-Dum",
+        code: "kd",
+        type: "zawodowa",
+        races: ["krasnolud", "gnom"],
+        paths: [
+            {
+                name: "default",
+                activePlayers: 2,
+                specs: ["krasnoludzka riposta"],
+                skills: {
+                    "topory": 85,
+                    "mloty": 85,
+                    "walka w ciemnosci": 70,
+                    "parowanie": 60,
+                    "tarczownictwo": 80,
+                    "walke w szyku": 55,
+                    "ocena przeciwnika": 60,
+                    "ocena obiektu": 60,
+                    "plywanie": 75,
+                    "wspinaczke": 80,
+                    "wyczucie kierunku": 70,
+                    "tropienie": 75,
+                    "spostrzegawczosc": 70,
+                    "znajomosc jezykow": 60,
+                    "riposta": 100
+                }
+            }
+        ]
+    },
+    {
+        name: "Gwardia Katana",
+        code: "gk",
+        type: "zawodowa",
+        races: ["ork", "czlowiek"],
+        paths: [
+            {
+                name: "default",
+                activePlayers: 2,
+                specs: ["uderzenie tarcza", "ciecie szabla"],
+                skills: {
+                    "szable": 95,
+                    "bronie lancuchowe": 95,
+                    "parowanie": 70,
+                    "tarczownictwo": 75,
+                    "walke w szyku": 70,
+                    "ocena przeciwnika": 50,
+                    "ocena obiektu": 50,
+                    "szacowanie": 50,
+                    "plywanie": 60,
+                    "wspinaczke": 80,
+                    "wyczucie kierunku": 50,
+                    "tropienie": 60,
+                    "spostrzegawczosc": 60,
+                    "uderzenie tarcza": 100,
+                    "gwardyjski cios": 100
+                }
+            }
+        ]
+    },
+    {
+        name: "Druidzki Krag",
+        code: "dr",
+        type: "zawodowa",
+        races: ["czlowiek", "elf", "krasnolud", "goblin", "reptilion", "kmaran", "gnom", "niziolek"],
+        paths: [
+            {
+                name: "zmiennoksztaltny",
+                activePlayers: 7,
+                specs: ["zwinny cios"],
+                skills: {
+                    "walka bez broni": 80,
+                    "uniki": 75,
+                    "ocena przeciwnika": 55,
+                    "opieka nad zwierzetami": 60,
+                    "wyczucie kierunku": 60,
+                    "tropienie": 50,
+                    "spostrzegawczosc": 60,
+                    "jezdziectwo": 50,
+                    "skradanie sie": 40,
+                    "ukrywanie sie": 40,
+                    "zwinny cios": 100,
+                    "koncentracja": 50,
+                    "koncentracja w walce": 50,
+                    "przemiane": 80,
+                    "przywolywanie": 40
+                }
+            },
+            {
+                name: "przywolywacz",
+                activePlayers: 7,
+                specs: [],
+                skills: {
+                    "bronie drzewcowe": 60,
+                    "wlocznie": 60,
+                    "parowanie": 70,
+                    "ocena przeciwnika": 55,
+                    "opieka nad zwierzetami": 60,
+                    "wyczucie kierunku": 60,
+                    "tropienie": 50,
+                    "spostrzegawczosc": 60,
+                    "jezdziectwo": 50,
+                    "skradanie sie": 40,
+                    "ukrywanie sie": 40,
+                    "koncentracja": 70,
+                    "koncentracja w walce": 50,
+                    "iluzja": 70,
+                    "przywolywanie": 80
+                }
+            }
+        ]
+    },
+    {
+        name: "Armia Saurona",
+        code: "ar",
+        type: "zawodowa",
+        races: ["ork", "goblin", "reptilion"],
+        paths: [
+            {
+                name: "default",
+                activePlayers: 7,
+                specs: ["crush"],
+                skills: {
+                    "miecze": 85,
+                    "topory": 85,
+                    "maczugi": 85,
+                    "mloty": 85,
+                    "parowanie": 75,
+                    "tarczownictwo": 75,
+                    "walke w szyku": 65,
+                    "ocena przeciwnika": 70,
+                    "wspinaczke ": 70,
+                    "wyczucie kierunku": 70,
+                    "spostrzegawczosc": 75,
+                    "walke tarcza": 100
+                }
+            },
+
+        ]
+    },
+    {
+        name: "Bractwo Zywiolow",
+        code: "bz_o",
+        type: "zawodowa",
+        races: ["czlowiek", "elf", "krasnolud", "reptilion", "kmaran", "gnom", "niziolek"],
+        paths: [
+            {
+                name: "occ_magia ognia",
+                activePlayers: 2,
+                specs: [],
+                skills: {
+                    "ocena obiektu": 40,
+                    "szacowanie": 40,
+                    "znajomosc jezykow": 55,
+                    "magia ognia": 99,
+                    "magia powietrza": 67,
+                    "magia ziemi": 67,
+                    "magia wody": 67,
+                    "koncentracja": 90,
+                    "koncentracja w walce": 70,
+                    "magia runiczna": 40,
+                    "czarodziejstwo": 40,
+                    "przemiane": 40,
+                    "zaklinanie": 35,
+                    "rozpraszanie": 40
+                }
+            },
+            {
+                name: "occ_magia powietrza",
+                activePlayers: 1,
+                specs: [],
+                skills: {
+                    "ocena obiektu": 40,
+                    "szacowanie": 40,
+                    "znajomosc jezykow": 55,
+                    "magia ognia": 67,
+                    "magia powietrza": 99,
+                    "magia ziemi": 67,
+                    "magia wody": 67,
+                    "koncentracja": 90,
+                    "koncentracja w walce": 70,
+                    "magia runiczna": 40,
+                    "czarodziejstwo": 40,
+                    "przemiane": 40,
+                    "zaklinanie": 35,
+                    "rozpraszanie": 40
+                }
+            },
+            {
+                name: "occ_magia wody",
+                activePlayers: 1,
+                specs: [],
+                skills: {
+                    "ocena obiektu": 40,
+                    "szacowanie": 40,
+                    "znajomosc jezykow": 55,
+                    "magia ognia": 67,
+                    "magia powietrza": 67,
+                    "magia ziemi": 67,
+                    "magia wody": 99,
+                    "koncentracja": 90,
+                    "koncentracja w walce": 70,
+                    "magia runiczna": 40,
+                    "czarodziejstwo": 40,
+                    "przemiane": 40,
+                    "zaklinanie": 35,
+                    "rozpraszanie": 40
+                }
+            },
+            {
+                name: "occ_general",
+                activePlayers: 1,
+                specs: [],
+                skills: {
+                    "ocena obiektu": 40,
+                    "szacowanie": 40,
+                    "znajomosc jezykow": 55,
+                    "magia ognia": 75,
+                    "magia powietrza": 75,
+                    "magia ziemi": 75,
+                    "magia wody": 75,
+                    "koncentracja": 90,
+                    "koncentracja w walce": 70,
+                    "magia runiczna": 40,
+                    "czarodziejstwo": 40,
+                    "przemiane": 40,
+                    "zaklinanie": 35,
+                    "rozpraszanie": 40
+                }
+            },
+            {
+                name: "occ_magia ziemi",
+                activePlayers: 1,
+                specs: [],
+                skills: {
+                    "ocena obiektu": 40,
+                    "szacowanie": 40,
+                    "znajomosc jezykow": 55,
+                    "magia ognia": 67,
+                    "magia powietrza": 67,
+                    "magia ziemi": 99,
+                    "magia wody": 67,
+                    "koncentracja": 90,
+                    "koncentracja w walce": 70,
+                    "magia runiczna": 40,
+                    "czarodziejstwo": 40,
+                    "przemiane": 40,
+                    "zaklinanie": 35,
+                    "rozpraszanie": 40
+                }
+            }
+        ]
+    }
+];

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="pl">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,90 +9,112 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.0.0/css/all.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
+
 <body>
     <div class="min-h-screen p-4">
         <div class="container mx-auto">
             <header class="flex justify-between items-center mb-6">
                 <h1 class="text-3xl font-bold">Warlock MUD Kalkulator Postaci</h1>
-                <div class="flex items-center">
-                    <span class="mr-2"><i class="fas fa-sun"></i></span>
-                    <div class="relative inline-block w-12 mr-2 align-middle select-none">
-                        <input type="checkbox" id="themeToggle" class="toggle-checkbox absolute block w-6 h-6 rounded-full bg-white border-4 appearance-none cursor-pointer" />
-                        <label for="themeToggle" class="toggle-label block overflow-hidden h-6 rounded-full bg-gray-300 cursor-pointer"></label>
+                <div class="flex items-center space-x-4">
+                    <div class="flex items-center">
+                        <span class="mr-1 text-sm font-medium" title="Pokaż/Ukryj bazowe umiejętności GP">GP
+                            Skills</span>
+                        <span id="gpSkillsStatus" class="text-xs font-bold mr-2 w-6 text-center">ON</span>
+                        <div class="relative inline-block w-10 mr-2 align-middle select-none">
+                            <input type="checkbox" id="gpSkillsToggle"
+                                class="toggle-checkbox absolute block w-5 h-5 rounded-full bg-white border-4 appearance-none cursor-pointer" />
+                            <label for="gpSkillsToggle"
+                                class="toggle-label block overflow-hidden h-5 rounded-full bg-gray-300 cursor-pointer"></label>
+                        </div>
                     </div>
-                    <span><i class="fas fa-moon"></i></span>
+                    <div class="flex items-center">
+                        <span class="mr-2"><i class="fas fa-sun"></i></span>
+                        <div class="relative inline-block w-10 mr-2 align-middle select-none">
+                            <input type="checkbox" id="themeToggle"
+                                class="toggle-checkbox absolute block w-5 h-5 rounded-full bg-white border-4 appearance-none cursor-pointer" />
+                            <label for="themeToggle"
+                                class="toggle-label block overflow-hidden h-5 rounded-full bg-gray-300 cursor-pointer"></label>
+                        </div>
+                        <span><i class="fas fa-moon"></i></span>
+                    </div>
                 </div>
             </header>
 
             <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 <div class="lg:col-span-1">
                     <div class="card rounded-lg shadow p-4 mb-6">
-    <h2 class="text-xl font-semibold mb-4">Wybór Gildii i Ścieżki</h2>
-    <div class="mb-6 guild-section">
-        <div class="mb-4">
-            <label for="guildSelect" class="block mb-2">Gildia Zawodowa:</label>
-            <select id="guildSelect" class="w-full p-2 border rounded bg-transparent border-gray-400">
-                <option value="">Wybierz gildię...</option>
-            </select>
-        </div>
+                        <h2 class="text-xl font-semibold mb-4">Wybór Gildii i Ścieżki</h2>
+                        <div class="mb-6 guild-section">
+                            <div class="mb-4">
+                                <label for="guildSelect" class="block mb-2">Gildia Zawodowa:</label>
+                                <select id="guildSelect"
+                                    class="w-full p-2 border rounded bg-transparent border-gray-400">
+                                    <option value="">Wybierz gildię...</option>
+                                </select>
+                            </div>
 
-        <div class="mb-4">
-            <label for="pathSelect" class="block mb-2">Ścieżka Gildii Zawodowej:</label>
-            <select id="pathSelect" class="w-full p-2 border rounded bg-transparent border-gray-400">
-                <option value="">Najpierw wybierz gildię...</option>
-            </select>
-        </div>
+                            <div class="mb-4">
+                                <label for="pathSelect" class="block mb-2">Ścieżka Gildii Zawodowej:</label>
+                                <select id="pathSelect"
+                                    class="w-full p-2 border rounded bg-transparent border-gray-400">
+                                    <option value="">Najpierw wybierz gildię...</option>
+                                </select>
+                            </div>
 
-        <div id="racesAllowed" class="mb-4">
-            <h3 class="font-medium mb-1">Dozwolone rasy (gildia zawodowa):</h3>
-            <p class="text-sm">Wybierz gildię zawodową, aby zobaczyć dozwolone rasy.</p>
-        </div>
+                            <div id="racesAllowed" class="mb-4">
+                                <h3 class="font-medium mb-1">Dozwolone rasy (gildia zawodowa):</h3>
+                                <p class="text-sm">Wybierz gildię zawodową, aby zobaczyć dozwolone rasy.</p>
+                            </div>
 
-        <div id="activePlayers" class="text-sm">
-            <p>Aktywnych graczy (gildia zawodowa): -</p>
-        </div>
-    </div>
-    <div class="mb-6 guild-section">
-        <div class="mb-4">
-            <label for="semiGuildSelect" class="block mb-2">Gildia Półzawodowa:</label>
-            <select id="semiGuildSelect" class="w-full p-2 border rounded bg-transparent border-gray-400">
-                <option value="">Wybierz gildię...</option>
-            </select>
-        </div>
+                            <div id="activePlayers" class="text-sm">
+                                <p>Aktywnych graczy (gildia zawodowa): -</p>
+                            </div>
+                        </div>
+                        <div class="mb-6 guild-section">
+                            <div class="mb-4">
+                                <label for="semiGuildSelect" class="block mb-2">Gildia Półzawodowa:</label>
+                                <select id="semiGuildSelect"
+                                    class="w-full p-2 border rounded bg-transparent border-gray-400">
+                                    <option value="">Wybierz gildię...</option>
+                                </select>
+                            </div>
 
-        <div class="mb-4">
-            <label for="semiPathSelect" class="block mb-2">Ścieżka Gildii Półzawodowej:</label>
-            <select id="semiPathSelect" class="w-full p-2 border rounded bg-transparent border-gray-400">
-                <option value="">Najpierw wybierz gildię półzawodową...</option>
-            </select>
-        </div>
+                            <div class="mb-4">
+                                <label for="semiPathSelect" class="block mb-2">Ścieżka Gildii Półzawodowej:</label>
+                                <select id="semiPathSelect"
+                                    class="w-full p-2 border rounded bg-transparent border-gray-400">
+                                    <option value="">Najpierw wybierz gildię półzawodową...</option>
+                                </select>
+                            </div>
 
-        <div id="semiRacesAllowed" class="mb-4">
-            <h3 class="font-medium mb-1">Dozwolone rasy (gildia półzawodowa):</h3>
-            <p class="text-sm">Wybierz gildię półzawodową, aby zobaczyć dozwolone rasy.</p>
-        </div>
+                            <div id="semiRacesAllowed" class="mb-4">
+                                <h3 class="font-medium mb-1">Dozwolone rasy (gildia półzawodowa):</h3>
+                                <p class="text-sm">Wybierz gildię półzawodową, aby zobaczyć dozwolone rasy.</p>
+                            </div>
 
-        <div id="semiActivePlayers" class="text-sm">
-            <p>Aktywnych graczy (gildia półzawodowa): -</p>
-        </div>
-    </div>
-</div>
+                            <div id="semiActivePlayers" class="text-sm">
+                                <p>Aktywnych graczy (gildia półzawodowa): -</p>
+                            </div>
+                        </div>
+                    </div>
 
                     <div class="card rounded-lg shadow p-4">
                         <div class="flex justify-between items-center mb-4">
                             <h2 class="text-xl font-semibold">Słowa</h2>
                             <div>
                                 <span class="text-sm mr-2">Wybrano: <span id="selectedWordCount">0</span></span>
-                                <button id="clearSelections" class="text-sm px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600">Wyczyść</button>
+                                <button id="clearSelections"
+                                    class="text-sm px-2 py-1 bg-red-500 text-white rounded hover:bg-red-600">Wyczyść</button>
                             </div>
                         </div>
 
                         <div class="mb-4">
-                            <input type="text" id="searchWords" placeholder="Szukaj słów..." class="w-full p-2 border rounded bg-transparent border-gray-400">
+                            <input type="text" id="searchWords" placeholder="Szukaj słów..."
+                                class="w-full p-2 border rounded bg-transparent border-gray-400">
                         </div>
 
                         <div id="wordsList" class="overflow-y-auto max-h-96 grid grid-cols-1 sm:grid-cols-2 gap-2">
-                            </div>
+                        </div>
                     </div>
                 </div>
 
@@ -99,13 +122,20 @@
                     <div class="card rounded-lg shadow p-4 mb-6">
                         <div class="flex justify-between items-center mb-4">
                             <h2 class="text-xl font-semibold">Podsumowanie Umiejętności</h2>
-                            <button id="exportButton" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
-                                <i class="fas fa-download mr-1"></i> Eksportuj do .md
-                            </button>
+                            <div class="flex space-x-2"> <button id="exportMdButton"
+                                    class="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700 text-sm">
+                                    <i class="fas fa-download mr-1"></i> export do .MD
+                                </button>
+                                <button id="exportJsonButton"
+                                    class="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 text-sm">
+                                    <i class="fas fa-download mr-1"></i> export do JSON
+                                </button>
+                            </div>
                         </div>
 
                         <div id="skillsSummary" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <p class="text-center col-span-1 md:col-span-2">Wybierz gildię i ścieżkę, aby zobaczyć umiejętności.</p>
+                            <p class="text-center col-span-1 md:col-span-2">Wybierz gildię i ścieżkę, aby zobaczyć
+                                umiejętności.</p>
                         </div>
                     </div>
 
@@ -127,4 +157,5 @@
     <script src="skills_gp.js"></script>
     <script src="script.js"></script>
 </body>
+
 </html>

--- a/script.js
+++ b/script.js
@@ -1,34 +1,45 @@
 // Main App Logic
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
     populateGuildSelect();
     populateSemiGuildSelect();
     populateWordsList();
     setupEventListeners();
     setupDarkMode();
+    setupGpToggle(); // <-- NOWOŚĆ: Inicjalizacja przełącznika GP Skills
+    updateSkillsSummary(); // <-- Wywołaj raz na starcie, aby uwzględnić stan GP Toggle
 });
 
 let selectedMainGuildPath = null;
 
+// --- Funkcje populacji (bez zmian) ---
 function populateGuildSelect() {
     const guildSelect = document.getElementById('guildSelect');
-
-    guildsData.forEach(guild => {
-        const option = document.createElement('option');
-        option.value = guild.code;
-        option.textContent = guild.name;
-        guildSelect.appendChild(option);
-    });
+    // Upewnij się, że guildsData jest dostępne
+    if (typeof guildsData !== 'undefined') {
+        guildsData.forEach(guild => {
+            const option = document.createElement('option');
+            option.value = guild.code;
+            option.textContent = guild.name;
+            guildSelect.appendChild(option);
+        });
+    } else {
+        console.error("guildsData nie jest zdefiniowane!");
+    }
 }
 
 function populateSemiGuildSelect() {
     const semiGuildSelect = document.getElementById('semiGuildSelect');
-
-    semiGuildsData.forEach(guild => {
-        const option = document.createElement('option');
-        option.value = guild.code;
-        option.textContent = guild.name;
-        semiGuildSelect.appendChild(option);
-    });
+    // Upewnij się, że semiGuildsData jest dostępne
+    if (typeof semiGuildsData !== 'undefined') {
+        semiGuildsData.forEach(guild => {
+            const option = document.createElement('option');
+            option.value = guild.code;
+            option.textContent = guild.name;
+            semiGuildSelect.appendChild(option);
+        });
+    } else {
+        console.error("semiGuildsData nie jest zdefiniowane!");
+    }
 }
 
 function populatePathSelect(guildData, isSemiGuild = false) {
@@ -38,79 +49,106 @@ function populatePathSelect(guildData, isSemiGuild = false) {
         console.error(`Nie znaleziono elementu select o id: ${pathSelectId}`);
         return;
     }
-    pathSelect.innerHTML = '';
+    pathSelect.innerHTML = ''; // Clear existing options
 
+    // Default option when no guild is selected
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
     if (!guildData) {
-        const option = document.createElement('option');
-        option.value = '';
-        option.textContent = `Najpierw wybierz ${isSemiGuild ? 'gildię półzawodową' : 'gildię zawodową'}...`;
-        pathSelect.appendChild(option);
+        defaultOption.textContent = `Najpierw wybierz ${isSemiGuild ? 'gildię półzawodową' : 'gildię zawodową'}...`;
+        pathSelect.appendChild(defaultOption);
         return;
     }
 
-    const pathsToPopulate = isSemiGuild ? guildData.semipaths : guildData.paths;
+    // Add default option even if guild is selected but before paths
+    defaultOption.textContent = `Wybierz ścieżkę...`;
+    pathSelect.appendChild(defaultOption);
 
-    if (pathsToPopulate) {
+
+    const pathsToPopulate = isSemiGuild ? guildData.semipaths : guildData.paths;
+    if (pathsToPopulate && pathsToPopulate.length > 0) {
         pathsToPopulate.forEach(path => {
             const option = document.createElement('option');
             option.value = path.name;
             option.textContent = path.name;
             pathSelect.appendChild(option);
         });
-
-        // Trigger change to update skills - only if there are paths
-        if (pathSelect.options.length > 1) {
-            pathSelect.dispatchEvent(new Event('change'));
-        }
+        // Trigger change only if there are actual paths added besides the default
+        // if (pathSelect.options.length > 1) {
+        //     pathSelect.dispatchEvent(new Event('change')); // Don't auto-trigger change on populate
+        // }
     } else {
-        const option = document.createElement('option');
-        option.value = '';
-        option.textContent = `Brak ścieżek dla ${isSemiGuild ? 'tej gildii półzawodowej' : 'tej gildii zawodowej'}...`;
-        pathSelect.appendChild(option);
+        // If no paths, keep only the default option
+        pathSelect.innerHTML = ''; // Clear again
+        const noPathOption = document.createElement('option');
+        noPathOption.value = '';
+        noPathOption.textContent = `Brak ścieżek dla ${isSemiGuild ? 'tej gildii półzawodowej' : 'tej gildii zawodowej'}...`;
+        pathSelect.appendChild(noPathOption);
     }
+    // Reset path selection to default after populating
+    pathSelect.value = '';
 }
+
 
 function populateWordsList() {
     const wordsList = document.getElementById('wordsList');
+    // Upewnij się, że slowaData jest dostępne
+    if (typeof slowaData !== 'undefined') {
+        slowaData.forEach(word => {
+            const div = document.createElement('div');
+            div.className = 'tooltip-trigger relative'; // Added relative for tooltip positioning if needed
 
-    slowaData.forEach(word => {
-        const div = document.createElement('div');
-        div.className = 'tooltip-trigger';
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.className = 'custom-checkbox';
+            checkbox.id = `word_${word.name.replace(/\s+/g, '_')}`; // Ensure valid ID
+            checkbox.value = word.name;
+            checkbox.dataset.cost = word.cost;
 
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.className = 'custom-checkbox';
-        checkbox.id = `word_${word.name}`;
-        checkbox.value = word.name;
-        checkbox.dataset.cost = word.cost;
+            const label = document.createElement('label');
+            label.htmlFor = checkbox.id;
+            label.className = 'block p-2 border rounded mb-1 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer transition-colors';
+            label.innerHTML = `${word.name} <span class="text-sm text-gray-500 dark:text-gray-400">(${word.cost})</span>`;
 
-        const label = document.createElement('label');
-        label.htmlFor = `word_${word.name}`;
-        label.className = 'block p-2 border rounded mb-1 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer transition-colors';
-        label.innerHTML = `${word.name} <span class="text-sm text-gray-500 dark:text-gray-400">(${word.cost})</span>`;
+            const tooltip = document.createElement('div');
+            // Added Tailwind classes for better default tooltip styling
+            tooltip.className = 'tooltip absolute left-full top-0 ml-2 p-2 rounded bg-gray-800 text-white text-xs shadow-lg invisible opacity-0 transition-opacity duration-300 z-10 w-64'; // Adjust width (w-64) as needed
+            tooltip.innerHTML = `<p>${word.description}</p>`;
 
-        const tooltip = document.createElement('div');
-        tooltip.className = 'tooltip p-2 rounded bg-gray-800 text-white text-xs shadow-lg';
-        tooltip.innerHTML = `<p>${word.description}</p>`;
+            div.appendChild(checkbox);
+            div.appendChild(label);
+            div.appendChild(tooltip);
+            wordsList.appendChild(div);
 
-        div.appendChild(checkbox);
-        div.appendChild(label);
-        div.appendChild(tooltip);
-        wordsList.appendChild(div);
+            // Add hover listeners to the trigger for the tooltip
+            div.addEventListener('mouseenter', () => {
+                tooltip.classList.remove('invisible', 'opacity-0');
+                tooltip.classList.add('visible', 'opacity-100');
+            });
+            div.addEventListener('mouseleave', () => {
+                tooltip.classList.remove('visible', 'opacity-100');
+                tooltip.classList.add('invisible', 'opacity-0');
+            });
 
-        checkbox.addEventListener('change', function() {
-            if (this.checked) {
-                label.classList.add('selected-item');
-            } else {
-                label.classList.remove('selected-item');
-            }
-            updateSelectedWordCount();
-            updateSkillsSummary();
-            updateEffectsSummary();
+
+            checkbox.addEventListener('change', function () {
+                if (this.checked) {
+                    label.classList.add('selected-item', '!bg-indigo-500', 'dark:!bg-indigo-700', 'text-white'); // Use !important or more specific selectors if needed
+                } else {
+                    label.classList.remove('selected-item', '!bg-indigo-500', 'dark:!bg-indigo-700', 'text-white');
+                }
+                updateSelectedWordCount();
+                updateSkillsSummary(); // Recalculate skills on word change
+                updateEffectsSummary();
+            });
         });
-    });
+    } else {
+        console.error("slowaData nie jest zdefiniowane!");
+        wordsList.innerHTML = '<p>Błąd ładowania danych słów.</p>';
+    }
 }
 
+// --- Event Listeners Setup ---
 function setupEventListeners() {
     const guildSelect = document.getElementById('guildSelect');
     const semiGuildSelect = document.getElementById('semiGuildSelect');
@@ -118,45 +156,53 @@ function setupEventListeners() {
     const semiPathSelect = document.getElementById('semiPathSelect');
     const searchWordsInput = document.getElementById('searchWords');
     const clearSelectionsButton = document.getElementById('clearSelections');
-    const exportButton = document.getElementById('exportButton');
+    // NOWE Przyciski eksportu
+    const exportMdButton = document.getElementById('exportMdButton');
+    const exportJsonButton = document.getElementById('exportJsonButton');
 
     // Guild Selection
-    guildSelect.addEventListener('change', function() {
-        const selectedGuild = guildsData.find(g => g.code === this.value);
-        updateRacesAllowed(selectedGuild);
-        populatePathSelect(selectedGuild); // Wywołanie dla gildii zawodowej
+    guildSelect.addEventListener('change', function () {
+        const selectedGuild = (typeof guildsData !== 'undefined') ? guildsData.find(g => g.code === this.value) : null;
+        updateRacesAllowed(selectedGuild, false); // Specify it's not semi-guild
+        populatePathSelect(selectedGuild, false); // Populate for main guild
         updateSkillsSummary();
         updateActivePlayers();
+        // Reset semi-guild path if main guild changes? Optional.
+        // document.getElementById('semiPathSelect').value = '';
     });
 
     // semiGuild Selection
-    semiGuildSelect.addEventListener('change', function() {
-        const selectedSemiGuild = semiGuildsData.find(g => g.code === this.value);
-        updateRacesAllowed(selectedSemiGuild);
-        populatePathSelect(selectedSemiGuild, true); // Wywołanie dla gildii półzawodowej
+    semiGuildSelect.addEventListener('change', function () {
+        const selectedSemiGuild = (typeof semiGuildsData !== 'undefined') ? semiGuildsData.find(g => g.code === this.value) : null;
+        updateRacesAllowed(selectedSemiGuild, true); // Specify it's semi-guild
+        populatePathSelect(selectedSemiGuild, true); // Populate for semi guild
         updateSkillsSummary();
         updateActivePlayers();
+        // Reset main guild path if semi guild changes? Optional.
+        // document.getElementById('pathSelect').value = '';
     });
 
     // Path Selection (Main Guild)
-    pathSelect.addEventListener('change', function() {
+    pathSelect.addEventListener('change', function () {
         updateSkillsSummary();
-        updateActivePlayers();
+        updateActivePlayers(); // Update players/specs when path changes
     });
 
     // Path Selection (Semi Guild)
-    semiPathSelect.addEventListener('change', function() {
+    semiPathSelect.addEventListener('change', function () {
         updateSkillsSummary();
-        updateActivePlayers();
+        updateActivePlayers(); // Update players/specs when path changes
     });
 
     // Search Words
-    searchWordsInput.addEventListener('input', function() {
-        const searchTerm = this.value.toLowerCase();
+    searchWordsInput.addEventListener('input', function () {
+        const searchTerm = this.value.toLowerCase().trim();
         const words = document.querySelectorAll('#wordsList .tooltip-trigger');
 
         words.forEach(wordDiv => {
-            const wordName = wordDiv.querySelector('label').textContent.toLowerCase();
+            const label = wordDiv.querySelector('label');
+            // Ensure label exists and get text content safely
+            const wordName = label ? label.textContent.toLowerCase() : '';
             if (wordName.includes(searchTerm)) {
                 wordDiv.style.display = '';
             } else {
@@ -166,35 +212,58 @@ function setupEventListeners() {
     });
 
     // Clear Selections
-    clearSelectionsButton.addEventListener('click', function() {
+    clearSelectionsButton.addEventListener('click', function () {
+        // Clear checkboxes and styles
         const checkboxes = document.querySelectorAll('#wordsList input[type="checkbox"]');
         checkboxes.forEach(checkbox => {
             checkbox.checked = false;
-            checkbox.nextElementSibling.classList.remove('selected-item');
+            const label = checkbox.nextElementSibling;
+            if (label) {
+                label.classList.remove('selected-item', '!bg-indigo-500', 'dark:!bg-indigo-700', 'text-white');
+            }
         });
-        document.getElementById('guildSelect').value = '';
-        document.getElementById('pathSelect').innerHTML = '<option value="">Najpierw wybierz gildię...</option>';
-        document.getElementById('semiGuildSelect').value = '';
-        document.getElementById('semiPathSelect').innerHTML = '<option value="">Najpierw wybierz gildię półzawodową...</option>';
-        selectedMainGuildPath = null;
+
+        // Reset guild and path selects
+        guildSelect.value = '';
+        semiGuildSelect.value = '';
+
+        // Repopulate path selects to show default messages
+        populatePathSelect(null, false);
+        populatePathSelect(null, true);
+
+        // Clear race and player info
+        updateRacesAllowed(null); // Call once to reset both sections
+        updateActivePlayers();    // Call once to reset both sections
+
+        // Reset search
+        searchWordsInput.value = '';
+        searchWordsInput.dispatchEvent(new Event('input')); // Trigger search filter reset
+
+
+        // Update counts and summaries
         updateSelectedWordCount();
         updateSkillsSummary();
         updateEffectsSummary();
     });
 
-    // Export Button
-    exportButton.addEventListener('click', exportToMarkdown);
+    // Export Buttons --- ZMIANA ---
+    exportMdButton.addEventListener('click', exportToMarkdown);
+    exportJsonButton.addEventListener('click', exportToJson); // <-- NOWOŚĆ
 }
 
+// --- Dark Mode Setup ---
 function setupDarkMode() {
     const themeToggle = document.getElementById('themeToggle');
-
+    // Apply theme on initial load
     if (localStorage.getItem('darkMode') === 'true') {
         document.documentElement.classList.add('dark');
         themeToggle.checked = true;
+    } else {
+        document.documentElement.classList.remove('dark');
+        themeToggle.checked = false;
     }
 
-    themeToggle.addEventListener('change', function() {
+    themeToggle.addEventListener('change', function () {
         if (this.checked) {
             document.documentElement.classList.add('dark');
             localStorage.setItem('darkMode', 'true');
@@ -205,35 +274,81 @@ function setupDarkMode() {
     });
 }
 
-function updateRacesAllowed(guild) {
+// --- NOWOŚĆ: GP Skills Toggle Setup ---
+function setupGpToggle() {
+    const gpSkillsToggle = document.getElementById('gpSkillsToggle');
+    const gpSkillsStatusSpan = document.getElementById('gpSkillsStatus'); // <-- NOWOŚĆ: Pobierz span statusu
+
+    // Funkcja pomocnicza do aktualizacji statusu
+    const updateGpToggleStatus = (enabled) => {
+        if (enabled) {
+            gpSkillsStatusSpan.textContent = 'ON';
+            gpSkillsStatusSpan.classList.remove('text-red-500', 'dark:text-red-400');
+            gpSkillsStatusSpan.classList.add('text-green-600', 'dark:text-green-400');
+        } else {
+            gpSkillsStatusSpan.textContent = 'OFF';
+            gpSkillsStatusSpan.classList.remove('text-green-600', 'dark:text-green-400');
+            gpSkillsStatusSpan.classList.add('text-red-500', 'dark:text-red-400');
+        }
+    };
+
+    // Apply state on initial load, default to true (ON) if not set
+    const gpEnabled = localStorage.getItem('gpSkillsEnabled') !== 'false'; // Default true
+    gpSkillsToggle.checked = gpEnabled;
+    updateGpToggleStatus(gpEnabled); // <-- NOWOŚĆ: Ustaw początkowy status
+
+    // Store initial state explicitly if it wasn't set
+    if (localStorage.getItem('gpSkillsEnabled') === null) {
+        localStorage.setItem('gpSkillsEnabled', 'true');
+    }
+
+
+    gpSkillsToggle.addEventListener('change', function () {
+        const isEnabled = this.checked; // <-- Zapisz stan
+        if (isEnabled) {
+            localStorage.setItem('gpSkillsEnabled', 'true');
+        } else {
+            localStorage.setItem('gpSkillsEnabled', 'false');
+        }
+        updateGpToggleStatus(isEnabled); // <-- NOWOŚĆ: Zaktualizuj status
+        updateSkillsSummary(); // Recalculate skills when toggle changes
+    });
+}
+
+// --- Update Functions (Races, Players, Word Count - drobne poprawki) ---
+function updateRacesAllowed(guild, isSemiGuild) {
     const racesAllowedDiv = document.getElementById('racesAllowed');
     const semiRacesAllowedDiv = document.getElementById('semiRacesAllowed');
 
-    // Resetuj obie sekcje, gdy nie ma wybranej gildii
-    if (!guild) {
-        racesAllowedDiv.innerHTML = '<h3 class="font-medium mb-1">Dozwolone rasy (gildia zawodowa):</h3><p class="text-sm">Wybierz gildię zawodową, aby zobaczyć dozwolone rasy.</p>';
-        semiRacesAllowedDiv.innerHTML = '<h3 class="font-medium mb-1">Dozwolone rasy (gildia półzawodowa):</h3><p class="text-sm">Wybierz gildię półzawodową, aby zobaczyć dozwolone rasy.</p>';
+    // If guild is null, reset both sections specifically
+    if (guild === null) {
+        racesAllowedDiv.innerHTML = '<h3 class="font-medium mb-1 text-sm">Dozwolone rasy (zawodowa):</h3><p class="text-xs italic">Wybierz gildię...</p>';
+        semiRacesAllowedDiv.innerHTML = '<h3 class="font-medium mb-1 text-sm">Dozwolone rasy (półzawodowa):</h3><p class="text-xs italic">Wybierz gildię...</p>';
         return;
     }
 
-    let html = '<h3 class="font-medium mb-1">Dozwolone rasy:</h3>';
-    if (guild.races && guild.races.length > 0) {
-        html += `<p class="text-sm">${formatRacesList(guild.races)}</p>`;
+    let html = '';
+    if (guild && guild.races && guild.races.length > 0) {
+        html += `<p class="text-xs">${formatRacesList(guild.races)}</p>`;
     } else {
-        html += '<p class="text-sm">Brak informacji o dozwolonych rasach.</p>';
+        html += '<p class="text-xs italic">Brak informacji o rasach.</p>';
     }
 
-    // Sprawdź, czy gildia pochodzi z guildsData czy semiGuildsData
-    if (guildsData.some(g => g.code === guild.code)) {
-        racesAllowedDiv.innerHTML = `<h3 class="font-medium mb-1">Dozwolone rasy (gildia zawodowa):</h3>${html}`;
-        semiRacesAllowedDiv.innerHTML = '<h3 class="font-medium mb-1">Dozwolone rasy (gildia półzawodowa):</h3><p class="text-sm">Wybierz gildię półzawodową, aby zobaczyć dozwolone rasy.</p>';
-    } else if (semiGuildsData.some(g => g.code === guild.code)) {
-        semiRacesAllowedDiv.innerHTML = `<h3 class="font-medium mb-1">Dozwolone rasy (gildia półzawodowa):</h3>${html}`;
-        racesAllowedDiv.innerHTML = '<h3 class="font-medium mb-1">Dozwolone rasy (gildia zawodowa):</h3><p class="text-sm">Wybierz gildię zawodową, aby zobaczyć dozwolone rasy.</p>';
+    // Update the correct section based on isSemiGuild flag
+    if (isSemiGuild) {
+        semiRacesAllowedDiv.innerHTML = `<h3 class="font-medium mb-1 text-sm">Dozwolone rasy (półzawodowa):</h3>${html}`;
+        // Optionally reset the other section if you want only one active at a time
+        // racesAllowedDiv.innerHTML = '<h3 class="font-medium mb-1 text-sm">Dozwolone rasy (zawodowa):</h3><p class="text-xs italic">Wybierz gildię...</p>';
+    } else {
+        racesAllowedDiv.innerHTML = `<h3 class="font-medium mb-1 text-sm">Dozwolone rasy (zawodowa):</h3>${html}`;
+        // Optionally reset the other section
+        // semiRacesAllowedDiv.innerHTML = '<h3 class="font-medium mb-1 text-sm">Dozwolone rasy (półzawodowa):</h3><p class="text-xs italic">Wybierz gildię...</p>';
     }
 }
 
+
 function formatRacesList(races) {
+    // Capitalize first letter of each race
     return races.map(race => race.charAt(0).toUpperCase() + race.slice(1)).join(', ');
 }
 
@@ -245,28 +360,36 @@ function updateActivePlayers() {
     const activePlayersDiv = document.getElementById('activePlayers');
     const semiActivePlayersDiv = document.getElementById('semiActivePlayers');
 
-    // Resetuj obie sekcje
-    activePlayersDiv.innerHTML = '<p>Aktywnych graczy (gildia zawodowa): -</p>';
-    semiActivePlayersDiv.innerHTML = '<p>Aktywnych graczy (gildia półzawodowa): -</p>';
+    // Reset both sections initially
+    activePlayersDiv.innerHTML = '<p class="text-xs">Aktywni (zawodowa): -</p>';
+    semiActivePlayersDiv.innerHTML = '<p class="text-xs">Aktywni (półzawodowa): -</p>';
 
-    if (semiGuildSelect.value) {
+    // Update Semi-Guild Players/Specs
+    if (semiGuildSelect.value && typeof semiGuildsData !== 'undefined') {
         const selectedSemiGuild = semiGuildsData.find(g => g.code === semiGuildSelect.value);
-        const selectedSemiPath = selectedSemiGuild && selectedSemiGuild.semipaths ? selectedSemiGuild.semipaths.find(p => p.name === semiPathSelect.value) : null;
-        if (selectedSemiPath) {
-            semiActivePlayersDiv.innerHTML = `<p>Aktywnych graczy (półzawodowa): ${selectedSemiPath.activePlayers}</p>`;
-            if (selectedSemiPath.specs && selectedSemiPath.specs.length > 0) {
-                semiActivePlayersDiv.innerHTML += `<p class="mt-2">Specjalne umiejętności (półzawodowa): ${selectedSemiPath.specs.join(', ')}</p>`;
+        if (selectedSemiGuild && selectedSemiGuild.semipaths) {
+            const selectedSemiPath = selectedSemiGuild.semipaths.find(p => p.name === semiPathSelect.value);
+            if (selectedSemiPath) {
+                let semiHtml = `<p class="text-xs">Aktywni (półzawodowa): ${selectedSemiPath.activePlayers ?? '-'}</p>`;
+                if (selectedSemiPath.specs && selectedSemiPath.specs.length > 0) {
+                    semiHtml += `<p class="mt-1 text-xs">Spec: ${selectedSemiPath.specs.join(', ')}</p>`;
+                }
+                semiActivePlayersDiv.innerHTML = semiHtml;
             }
         }
     }
 
-    if (guildSelect.value) {
+    // Update Main Guild Players/Specs
+    if (guildSelect.value && typeof guildsData !== 'undefined') {
         const selectedGuild = guildsData.find(g => g.code === guildSelect.value);
-        const selectedPath = selectedGuild && selectedGuild.paths ? selectedGuild.paths.find(p => p.name === pathSelect.value) : null;
-        if (selectedPath) {
-            activePlayersDiv.innerHTML = `<p>Aktywnych graczy (zawodowa): ${selectedPath.activePlayers}</p>`;
-            if (selectedPath.specs && selectedPath.specs.length > 0) {
-                activePlayersDiv.innerHTML += `<p class="mt-2">Specjalne umiejętności (zawodowa): ${selectedPath.specs.join(', ')}</p>`;
+        if (selectedGuild && selectedGuild.paths) {
+            const selectedPath = selectedGuild.paths.find(p => p.name === pathSelect.value);
+            if (selectedPath) {
+                let mainHtml = `<p class="text-xs">Aktywni (zawodowa): ${selectedPath.activePlayers ?? '-'}</p>`;
+                if (selectedPath.specs && selectedPath.specs.length > 0) {
+                    mainHtml += `<p class="mt-1 text-xs">Spec: ${selectedPath.specs.join(', ')}</p>`;
+                }
+                activePlayersDiv.innerHTML = mainHtml;
             }
         }
     }
@@ -278,283 +401,466 @@ function updateSelectedWordCount() {
     document.getElementById('selectedWordCount').textContent = selectedWords.length;
 }
 
+// --- NOWOŚĆ / ZMIANA: Logika obliczania i wyświetlania umiejętności ---
 function updateSkillsSummary() {
+    const gpSkillsToggle = document.getElementById('gpSkillsToggle');
+    const skillsSummaryDiv = document.getElementById('skillsSummary');
     const guildSelect = document.getElementById('guildSelect');
     const semiGuildSelect = document.getElementById('semiGuildSelect');
     const pathSelect = document.getElementById('pathSelect');
     const semiPathSelect = document.getElementById('semiPathSelect');
-    const skillsSummaryDiv = document.getElementById('skillsSummary');
 
-    const selectedMainGuild = guildsData.find(g => g.code === guildSelect.value);
-    const selectedSemiGuild = semiGuildsData.find(g => g.code === semiGuildSelect.value);
+    const gpEnabled = gpSkillsToggle.checked;
 
-    const selectedMainPath = selectedMainGuild && selectedMainGuild.paths ? selectedMainGuild.paths.find(p => p.name === pathSelect.value) : null;
-    const selectedSemiPath = selectedSemiGuild && selectedSemiGuild.semipaths ? selectedSemiGuild.semipaths.find(sp => sp.name === semiPathSelect.value) : null;
+    // Find selected guilds and paths data
+    const selectedMainGuild = (typeof guildsData !== 'undefined' && guildSelect.value)
+        ? guildsData.find(g => g.code === guildSelect.value) : null;
+    const selectedSemiGuild = (typeof semiGuildsData !== 'undefined' && semiGuildSelect.value)
+        ? semiGuildsData.find(g => g.code === semiGuildSelect.value) : null;
 
-    let baseSkills = {...skillsGp};
+    const selectedMainPath = (selectedMainGuild && selectedMainGuild.paths && pathSelect.value)
+        ? selectedMainGuild.paths.find(p => p.name === pathSelect.value) : null;
+    const selectedSemiPath = (selectedSemiGuild && selectedSemiGuild.semipaths && semiPathSelect.value)
+        ? selectedSemiGuild.semipaths.find(sp => sp.name === semiPathSelect.value) : null;
 
-    if (selectedMainPath) {
+    // --- Core Logic for Combining Skills ---
+    let baseSkills = {};
+    const combinedGuildSkills = {};
+
+    // 1. Combine skills from selected main and semi guild paths, taking the higher value
+    if (selectedMainPath && selectedMainPath.skills) {
         for (const skill in selectedMainPath.skills) {
-            baseSkills[skill] = Math.max(baseSkills[skill] || 0, selectedMainPath.skills[skill]);
+            combinedGuildSkills[skill] = Math.max(combinedGuildSkills[skill] || 0, selectedMainPath.skills[skill]);
         }
     }
-
-    if (selectedSemiPath) {
+    if (selectedSemiPath && selectedSemiPath.skills) {
         for (const skill in selectedSemiPath.skills) {
-            baseSkills[skill] = Math.max(baseSkills[skill] || 0, selectedSemiPath.skills[skill]);
+            combinedGuildSkills[skill] = Math.max(combinedGuildSkills[skill] || 0, selectedSemiPath.skills[skill]);
         }
     }
 
-    const modifiedSkills = calculateModifiedSkills(baseSkills);
+    // 2. Incorporate GP skills based on the toggle state
+    if (typeof skillsGp !== 'undefined') {
+        if (gpEnabled) {
+            // GP ON: Merge GP and Guild skills, taking the higher value for overlaps
+            // Start with all GP skills
+            baseSkills = { ...skillsGp };
+            // Merge guild skills, overriding or adding if higher/new
+            for (const skill in combinedGuildSkills) {
+                baseSkills[skill] = Math.max(baseSkills[skill] || 0, combinedGuildSkills[skill]);
+            }
+        } else {
+            // GP OFF: Only use skills present in selected guilds.
+            // GP skills that overlap are implicitly included via combinedGuildSkills.
+            // GP skills *not* in guilds are excluded.
+            baseSkills = { ...combinedGuildSkills };
+        }
+    } else {
+        // Fallback if skillsGp is missing
+        console.error("skillsGp nie jest zdefiniowane!");
+        baseSkills = { ...combinedGuildSkills };
+    }
+    // --- End Core Logic ---
 
-    skillsSummaryDiv.innerHTML = '';
 
-    Object.entries(modifiedSkills).forEach(([skillName, value]) => {
+    // Calculate final skills after applying word effects
+    const modifiedSkills = calculateModifiedSkills(baseSkills); // Pass the correctly calculated base
+
+    // --- Display Logic ---
+    skillsSummaryDiv.innerHTML = ''; // Clear previous summary
+
+    if (Object.keys(modifiedSkills).length === 0) {
+        skillsSummaryDiv.innerHTML = '<p class="text-center col-span-1 md:col-span-2 italic text-sm">Wybierz gildię/ścieżkę lub włącz GP Skills, aby zobaczyć umiejętności.</p>';
+        return;
+    }
+
+    // Sort skills alphabetically for consistent display
+    const sortedSkillNames = Object.keys(modifiedSkills).sort();
+
+
+    sortedSkillNames.forEach(skillName => {
+        const value = modifiedSkills[skillName];
         const displayName = skillName.charAt(0).toUpperCase() + skillName.slice(1);
+        // Get the base value *after* GP toggle logic but *before* word mods
         const originalBaseValue = baseSkills[skillName] || 0;
         const difference = value - originalBaseValue;
 
         const skillDiv = document.createElement('div');
-        skillDiv.className = 'mb-3 relative'; // Dodajemy 'relative', aby móc pozycjonować absolutnie element z różnicą
+        // Added min-w-0 to prevent flex items from overflowing in rare cases
+        skillDiv.className = 'mb-2 relative min-w-0';
 
         const nameElement = document.createElement('div');
-        nameElement.className = 'flex justify-between mb-1';
+        // Use flex for alignment, justify-between for spacing
+        nameElement.className = 'flex justify-between items-baseline mb-1 text-sm';
+        // Wrap skill name in span to prevent stretching
         nameElement.innerHTML = `
-            <span>${displayName}</span>
-            <span>${value}</span>
+            <span class="truncate pr-2">${displayName}</span>
+            <span class="font-semibold whitespace-nowrap">${value}</span>
         `;
 
-        // Wyświetlanie różnicy nad paskiem po prawej
+
+        // Display difference indicator only if there is a change
         if (difference !== 0) {
             const diffElement = document.createElement('div');
-            diffElement.className = 'skill-diff absolute top-[-1.2em] right-0 text-xs'; // Początkowe ustawienie 'right' na 0
+            // Position relative to the skillDiv, adjust top/right as needed
+            diffElement.className = 'skill-diff absolute -top-1 right-0 text-xs font-bold'; // Simplified positioning
             diffElement.textContent = (difference > 0 ? '+' : '') + difference;
             diffElement.classList.add(difference > 0 ? 'text-green-500' : 'text-red-500');
+            // Ensure difference doesn't overlap value - might need tweaking
+            nameElement.querySelector('.font-semibold').style.marginRight = '2.5em'; // Add margin to value span
             skillDiv.appendChild(diffElement);
         }
 
         const barContainer = document.createElement('div');
-        barContainer.className = 'skill-bar w-full h-2 rounded-full';
+        // Use background color variables for theme compatibility
+        barContainer.className = 'skill-bar w-full h-2 rounded-full bg-gray-200 dark:bg-gray-600 overflow-hidden'; // Added overflow-hidden
 
         const barFill = document.createElement('div');
-        barFill.className = 'skill-bar-fill h-full rounded-full';
-        barFill.style.width = `${Math.min(value, 100)}%`;
+        // Use background color variables and ensure value doesn't exceed 100% for width
+        barFill.className = 'skill-bar-fill h-full rounded-full bg-indigo-500 dark:bg-indigo-600 transition-width duration-300 ease-in-out'; // Added transition
+        barFill.style.width = `${Math.max(0, Math.min(value, 100))}%`; // Clamp value between 0 and 100
 
         barContainer.appendChild(barFill);
-        skillDiv.appendChild(nameElement);
-        skillDiv.appendChild(barContainer);
+        skillDiv.appendChild(nameElement); // Add name/value first
+        skillDiv.appendChild(barContainer); // Then add bar
 
         skillsSummaryDiv.appendChild(skillDiv);
     });
 }
 
+
+// --- Calculate Modified Skills ---
+// --- ZMIANY W MAPOWANIU STATYSTYK ---
 function calculateModifiedSkills(baseSkills) {
-    const modifiedSkills = {...baseSkills};
+    const modifiedSkills = { ...baseSkills }; // Work on a copy
     const selectedWords = document.querySelectorAll('#wordsList input[type="checkbox"]:checked');
 
-    selectedWords.forEach(checkbox => {
-        const wordName = checkbox.value;
-        const word = slowaData.find(w => w.name === wordName);
+    if (typeof slowaData !== 'undefined') {
+        selectedWords.forEach(checkbox => {
+            const wordName = checkbox.value;
+            const word = slowaData.find(w => w.name === wordName);
 
-        if (word && word.effects) {
-            word.effects.forEach(effect => {
-                const effectValue = parseInt(effect.value);
+            if (word && word.effects) {
+                word.effects.forEach(effect => {
+                    // Skip special effects that don't modify skills directly here
+                    if (effect.type === 'special' && effect.description.includes('zamienia ze soba')) {
+                        // Handle swap logic (existing)
+                        if (effect.description === "zamienia ze soba umiejetnosci w skutecznym uzywaniu tarczy i w walce dwiema bronmi jednoczesnie") {
+                            const skill1 = "tarczownictwo";
+                            const skill2 = "walka dwiema bronmi";
+                            const val1 = baseSkills[skill1] || 0;
+                            const val2 = baseSkills[skill2] || 0;
+                            const diff = val1 - val2;
+                            modifiedSkills[skill1] = (modifiedSkills[skill1] || 0) - diff;
+                            modifiedSkills[skill2] = (modifiedSkills[skill2] || 0) + diff;
+                        } else if (effect.description === "zamienia ze soba umiejetnosci w poslugiwaniu sie magia zycia i w poslugiwaniu sie magia mroku") {
+                            const skill1 = "magia zycia";
+                            const skill2 = "magia mroku";
+                            const val1 = baseSkills[skill1] || 0;
+                            const val2 = baseSkills[skill2] || 0;
+                            const diff = val1 - val2;
+                            modifiedSkills[skill1] = (modifiedSkills[skill1] || 0) - diff;
+                            modifiedSkills[skill2] = (modifiedSkills[skill2] || 0) + diff;
+                        } else if (effect.description === "zamienia ze soba umiejetnosci w parowaniu ciosow przeciwnika i w unikaniu ciosow przeciwnika") {
+                            // TODO: Implement swap logic for parowanie/uniki if needed
+                            console.warn("Swap effect for parowanie/uniki not fully implemented yet.");
+                        }
+                        return; // Continue to next effect after handling swap
+                    }
 
-                if (modifiedSkills.hasOwnProperty(effect.stat)) {
-                    modifiedSkills[effect.stat] += effectValue;
-                } else if (effect.stat === "umiejetnosci walki wszystkimi bronmi") {
-                    const combatSkills = ["miecze", "sztylety", "topory", "mloty", "wlocznie", "szable", "bronie drzewcowe", "bronie lancuchowe", "maczugi"];
-                    combatSkills.forEach(skill => {
-                        if (modifiedSkills.hasOwnProperty(skill)) {
-                            modifiedSkills[skill] += effectValue;
+                    // Skip effects that are not increases or decreases or are special non-swap ones
+                    if (effect.type !== 'increase' && effect.type !== 'decrease') {
+                        // console.log(`Skipping non-skill mod effect for word "${wordName}": ${effect.description || effect.stat}`);
+                        return;
+                    }
+
+                    const effectValue = parseInt(effect.value);
+                    if (isNaN(effectValue)) {
+                        console.warn(`Invalid effect value for word "${wordName}", stat "${effect.stat}": ${effect.value}`);
+                        return; // Skip if value is not a number
+                    }
+
+                    const stat = effect.stat.toLowerCase().trim(); // Normalize stat name
+
+                    // --- Start Mapping Logic ---
+                    let targetSkill = null;
+
+                    // 1. Direct skill name match (e.g., "wytrzymalosc", "sile", "zrecznosc" - but these are attributes, not skills usually)
+                    if (modifiedSkills.hasOwnProperty(stat)) {
+                        targetSkill = stat;
+                    }
+                    // 2. Broad categories
+                    else if (stat === "umiejetnosci walki wszystkimi bronmi") {
+                        const combatSkills = ["miecze", "sztylety", "topory", "mloty", "wlocznie", "szable", "bronie drzewcowe", "bronie lancuchowe", "maczugi", "bicze", "luki", "kusze"]; // Exclude walka bez broni?
+                        combatSkills.forEach(skill => {
+                            if (modifiedSkills.hasOwnProperty(skill)) {
+                                modifiedSkills[skill] = (modifiedSkills[skill] || 0) + effectValue;
+                            }
+                        });
+                        return; // Handled multiple skills, continue to next effect
+                    } else if (stat === "umiejetnosci ze wszystkich szkol magii") {
+                        const magicSkills = ["magia ognia", "magia wody", "magia ziemi", "magia powietrza", "magia mroku", "iluzja", "przemiane", "przywolywanie", "magia runiczna", "czarodziejstwo", "magia zycia", "mistycyzm", "zaklinanie"]; // Ensure this list is complete
+                        magicSkills.forEach(skill => {
+                            if (modifiedSkills.hasOwnProperty(skill)) {
+                                modifiedSkills[skill] = (modifiedSkills[skill] || 0) + effectValue;
+                            }
+                        });
+                        return; // Handled multiple skills, continue to next effect
+                    }
+                    // 3. Specific descriptive mappings to skill keys
+                    else if (stat === "umiejetnosc w ocenianiu wlasnosci przedmiotow") targetSkill = "ocena obiektu";
+                    else if (stat === "umiejetnosc w szacowaniu wartosci przedmiotow") targetSkill = "szacowanie";
+                    else if (stat === "umiejetnosc w zawieraniu korzystnych transakcji handlowych") targetSkill = "targowanie sie";
+                    else if (stat === "umiejetnosc w wydobywaniu mineralow spod ziemi") targetSkill = "gornictwo";
+                    else if (stat === "umiejetnosc w metalurgii") targetSkill = "metalurgia";
+                    else if (stat === "umiejetnosc w walce bez broni") targetSkill = "walka bez broni";
+                    else if (stat === "umiejetnosc w skutecznym uzywaniu tarczy") targetSkill = "tarczownictwo";
+                    else if (stat === "umiejetnosc w parowaniu ciosow przeciwnika") targetSkill = "parowanie";
+                    else if (stat === "umiejetnosc w unikaniu ciosow przeciwnika") targetSkill = "uniki";
+                    else if (stat === "umiejetnosc w walce dwiema bronmi jednoczesnie") targetSkill = "walka dwiema bronmi";
+                    else if (stat === "umiejetnosc w walce z konskiego grzbietu") targetSkill = "walka konna";
+                    else if (stat === "umiejetnosc w walce w szyku") targetSkill = "walke w szyku"; // Uwaga na 'e'
+                    else if (stat === "umiejetnosc w wywieraniu wplywu na innych") targetSkill = "zdolnosci przywodcze";
+                    else if (stat === "umiejetnosc w poslugiwaniu sie magia ognia") targetSkill = "magia ognia";
+                    else if (stat === "umiejetnosc w poslugiwaniu sie magia powietrza") targetSkill = "magia powietrza";
+                    else if (stat === "umiejetnosc w poslugiwaniu sie magia ziemi") targetSkill = "magia ziemi";
+                    else if (stat === "umiejetnosc w poslugiwaniu sie magia wody") targetSkill = "magia wody";
+                    else if (stat === "umiejetnosc w poslugiwaniu sie magia zycia") targetSkill = "magia zycia"; // FIX for Kaznodzieja
+                    else if (stat === "umiejetnosc w poslugiwaniu sie magia mroku") targetSkill = "magia mroku";
+                    else if (stat === "umiejetnosc w poslugiwaniu sie magia przemiany") targetSkill = "przemiane"; // Uwaga na 'e'
+                    else if (stat === "umiejetnosc w mistycyzmie") targetSkill = "mistycyzm"; // FIX for Kaznodzieja, Mistycyzm
+                    else if (stat === "umiejetnosc w zaklinaniu") targetSkill = "zaklinanie";
+                    else if (stat === "umiejetnosc w magii tworzenia i przywolywania") targetSkill = "przywolywanie";
+                    else if (stat === "umiejetnosc w poslugiwaniu sie magia iluzji") targetSkill = "iluzja"; // FIX for Iluzja (uwaga na 'e')
+                    else if (stat === "umiejetnosc w rozpraszaniu zaklec") targetSkill = "rozpraszanie";
+                    else if (stat === "umiejetnosc w znajomosci i uzywaniu magii") targetSkill = "czarodziejstwo";
+                    else if (stat === "umiejetnosc w pisaniu i uzywaniu run") targetSkill = "magia runiczna";
+                    else if (stat === "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci") targetSkill = "koncentracja"; // FIX for koncentracje -> koncentracja
+                    else if (stat === "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki") targetSkill = "koncentracja w walce";
+                    else if (stat === "umiejetnosc w warzeniu i rozpoznawaniu mikstur") targetSkill = "alchemia";
+                    else if (stat === "umiejetnosc w znajdowaniu i rozpoznawaniu ziol") targetSkill = "zielarstwo";
+                    else if (stat === "umiejetnosc w wyczuwaniu slabosci wroga") targetSkill = "wyczucie slabosci"; // Dodane mapowanie
+
+                    // --- End Mapping Logic ---
+
+                    // Apply the modification if a target skill was found
+                    if (targetSkill && modifiedSkills.hasOwnProperty(targetSkill)) {
+                        modifiedSkills[targetSkill] = (modifiedSkills[targetSkill] || 0) + effectValue;
+                        // console.log(`Applied effect: ${wordName} -> ${stat} (${effectValue}) mapped to ${targetSkill}. New value: ${modifiedSkills[targetSkill]}`);
+                    } else if (targetSkill) {
+                        // This case means the mapping exists, but the base skill is 0 or missing from current selections
+                        // We could potentially add the skill if the effect is positive, but might clutter the list.
+                        // For now, only modify existing skills.
+                        // console.log(`Skill "${targetSkill}" (from "${stat}") not found in current base skills for word "${wordName}". Effect ignored.`);
+                    } else {
+                        // Stat wasn't mapped to a known skill and isn't a direct match - likely an attribute or unhandled effect.
+                        if (effect.type === 'increase' || effect.type === 'decrease') { // Only warn for actual +/- effects
+                            // console.warn(`Unhandled skill/stat modification for word "${wordName}": "${stat}" (${effectValue}). No mapping found.`);
                         }
-                    });
-                } else if (effect.stat === "umiejetnosci ze wszystkich szkol magii") {
-                    const magicSkills = ["magia ognia", "magia wody", "magia ziemi", "magia powietrza", "magia mroku", "iluzje", "przemiane", "przywolywanie", "magia runiczna", "czarodziejstwo"];
-                    magicSkills.forEach(skill => {
-                        if (modifiedSkills.hasOwnProperty(skill)) {
-                            modifiedSkills[skill] += effectValue;
-                        }
-                    });
-                }
-                // Specyficzne mapowania umiejętności
-                else if (effect.stat === "umiejetnosc w unikaniu ciosow przeciwnika" && modifiedSkills.hasOwnProperty("uniki")) {
-                    modifiedSkills["uniki"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w parowaniu ciosow przeciwnika" && modifiedSkills.hasOwnProperty("parowanie")) {
-                    modifiedSkills["parowanie"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w walce dwiema bronmi jednoczesnie" && modifiedSkills.hasOwnProperty("walka dwiema bronmi")) {
-                    modifiedSkills["walka dwiema bronmi"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w skutecznym uzywaniu tarczy" && modifiedSkills.hasOwnProperty("tarczownictwo")) {
-                    modifiedSkills["tarczownictwo"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w poslugiwaniu sie magia ognia" && modifiedSkills.hasOwnProperty("magia ognia")) {
-                    modifiedSkills["magia ognia"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w poslugiwaniu sie magia wody" && modifiedSkills.hasOwnProperty("magia wody")) {
-                    modifiedSkills["magia wody"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w poslugiwaniu sie magia ziemi" && modifiedSkills.hasOwnProperty("magia ziemi")) {
-                    modifiedSkills["magia ziemi"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w poslugiwaniu sie magia powietrza" && modifiedSkills.hasOwnProperty("magia powietrza")) {
-                    modifiedSkills["magia powietrza"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w poslugiwaniu sie magia mroku" && modifiedSkills.hasOwnProperty("magia mroku")) {
-                    modifiedSkills["magia mroku"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci" && modifiedSkills.hasOwnProperty("koncentracje")) {
-                    modifiedSkills["koncentracje"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki" && modifiedSkills.hasOwnProperty("koncentracja w walce")) {
-                    modifiedSkills["koncentracja w walce"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w rozpraszaniu zaklec" && modifiedSkills.hasOwnProperty("rozpraszanie")) {
-                    modifiedSkills["rozpraszanie"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w poslugiwaniu sie magia przemiany" && modifiedSkills.hasOwnProperty("przemiane")) {
-                    modifiedSkills["przemiane"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w magii tworzenia i przywolywania" && modifiedSkills.hasOwnProperty("przywolywanie")) {
-                    modifiedSkills["przywolywanie"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w poslugiwaniu sie magia iluzji" && modifiedSkills.hasOwnProperty("iluzje")) {
-                    modifiedSkills["iluzje"] += effectValue;
-                }
-                else if (effect.stat === "umiejetnosc w walce bez broni" && modifiedSkills.hasOwnProperty("walka bez broni")) {
-                    modifiedSkills["walka bez broni"] += effectValue;
-                }
-                else if (effect.stat === "wytrzymalosc" && modifiedSkills.hasOwnProperty("wytrzymalosc")) {
-                    modifiedSkills["wytrzymalosc"] += effectValue;
-                }
-                else if (effect.description === "zamienia ze soba umiejetnosci w skutecznym uzywaniu tarczy i w walce dwiema bronmi jednoczesnie") {
-                    const diff = baseSkills["tarczownictwo"] - baseSkills["walka dwiema bronmi"];
-                    modifiedSkills["tarczownictwo"] -= diff
-                    modifiedSkills["walka dwiema bronmi"] += diff
-                    console.log("Podmiana diff " + diff + " tarcza " + baseSkills["tarczownictwo"] + " 2h " + baseSkills["walka dwiema bronmi"]);
-                }
-                else if (effect.description === "zamienia ze soba umiejetnosci w poslugiwaniu sie magia zycia i w poslugiwaniu sie magia mroku") {
-                    const diff = baseSkills["magia zycia"] - baseSkills["magia mroku"];
-                    modifiedSkills["magia zycia"] -= diff
-                    modifiedSkills["magia mroku"] += diff
-                    console.log("Zdrada " + diff + " zycie " + baseSkills["magia zycia"] + " mrok " + baseSkills["magia mroku"]);
-                }
-            });
+                    }
+                });
+            }
+        });
+    } else {
+        console.error("slowaData nie jest zdefiniowane!");
+    }
+
+    // Ensure skills don't go below 0 (or other floor if needed)
+    for (const skill in modifiedSkills) {
+        if (modifiedSkills[skill] < 0) {
+            modifiedSkills[skill] = 0;
         }
-    });
+        // Optional: Cap skills at 100 or other max value if needed
+        // if (modifiedSkills[skill] > 100) {
+        //     modifiedSkills[skill] = 100;
+        // }
+    }
 
     return modifiedSkills;
 }
 
+
+// --- Update Effects Summary (bez zmian) ---
 function updateEffectsSummary() {
     const effectsSummaryDiv = document.getElementById('effectsSummary');
     const selectedWords = document.querySelectorAll('#wordsList input[type="checkbox"]:checked');
 
-    if (selectedWords.length === 0) {
-        effectsSummaryDiv.innerHTML = '<p>Wybierz słowa, aby zobaczyć ich efekty.</p>';
+    if (selectedWords.length === 0 || typeof slowaData === 'undefined') {
+        effectsSummaryDiv.innerHTML = '<p class="italic text-sm">Wybierz słowa, aby zobaczyć ich efekty.</p>';
         return;
     }
 
-    let html = '<ul class="list-disc pl-5">';
+    let html = '<ul class="list-disc pl-5 space-y-1 text-sm">';
     let totalCost = 0;
 
     selectedWords.forEach(checkbox => {
         const wordName = checkbox.value;
         const word = slowaData.find(w => w.name === wordName);
-        totalCost += parseInt(word.cost);
-
-        html += `<li class="mb-2"><span class="font-medium">${wordName}</span> (${word.cost}) - ${word.description}</li>`;
+        if (word) {
+            const cost = parseInt(word.cost) || 0;
+            totalCost += cost;
+            html += `<li class="mb-1"><span class="font-medium">${wordName}</span> (${cost}) - <span class="text-gray-600 dark:text-gray-400">${word.description}</span></li>`;
+        }
     });
-
     html += '</ul>';
     html = `<p class="mb-2 font-bold">Łączny koszt: ${totalCost}</p>` + html;
 
     effectsSummaryDiv.innerHTML = html;
 }
 
+// --- Helper to get current build data ---
+function getCurrentBuildData() {
+    const guildSelect = document.getElementById('guildSelect');
+    const pathSelect = document.getElementById('pathSelect');
+    const semiGuildSelect = document.getElementById('semiGuildSelect');
+    const semiPathSelect = document.getElementById('semiPathSelect');
+    const selectedWordCheckboxes = document.querySelectorAll('#wordsList input[type="checkbox"]:checked');
+
+    const selectedMainGuild = (typeof guildsData !== 'undefined' && guildSelect.value) ? guildsData.find(g => g.code === guildSelect.value) : null;
+    const selectedSemiGuild = (typeof semiGuildsData !== 'undefined' && semiGuildSelect.value) ? semiGuildsData.find(g => g.code === semiGuildSelect.value) : null;
+    const selectedMainPath = (selectedMainGuild && selectedMainGuild.paths && pathSelect.value) ? selectedMainGuild.paths.find(p => p.name === pathSelect.value) : null;
+    const selectedSemiPath = (selectedSemiGuild && selectedSemiGuild.semipaths && semiPathSelect.value) ? selectedSemiGuild.semipaths.find(sp => sp.name === semiPathSelect.value) : null;
+
+    const selectedWords = [];
+    let totalCost = 0;
+    if (typeof slowaData !== 'undefined') {
+        selectedWordCheckboxes.forEach(cb => {
+            const word = slowaData.find(w => w.name === cb.value);
+            if (word) {
+                selectedWords.push({ name: word.name, cost: word.cost, description: word.description });
+                totalCost += parseInt(word.cost) || 0;
+            }
+        });
+    }
+
+
+    // Recalculate base and modified skills to ensure consistency
+    const gpEnabled = document.getElementById('gpSkillsToggle').checked;
+    let baseSkills = {};
+    const combinedGuildSkills = {};
+    if (selectedMainPath && selectedMainPath.skills) {
+        for (const skill in selectedMainPath.skills) {
+            combinedGuildSkills[skill] = Math.max(combinedGuildSkills[skill] || 0, selectedMainPath.skills[skill]);
+        }
+    }
+    if (selectedSemiPath && selectedSemiPath.skills) {
+        for (const skill in selectedSemiPath.skills) {
+            combinedGuildSkills[skill] = Math.max(combinedGuildSkills[skill] || 0, selectedSemiPath.skills[skill]);
+        }
+    }
+    if (typeof skillsGp !== 'undefined') {
+        if (gpEnabled) {
+            baseSkills = { ...skillsGp };
+            for (const skill in combinedGuildSkills) {
+                baseSkills[skill] = Math.max(baseSkills[skill] || 0, combinedGuildSkills[skill]);
+            }
+        } else {
+            baseSkills = { ...combinedGuildSkills };
+        }
+    } else {
+        baseSkills = { ...combinedGuildSkills };
+    }
+
+    const finalSkills = calculateModifiedSkills(baseSkills);
+
+    return {
+        mainGuild: selectedMainGuild ? { name: selectedMainGuild.name, code: selectedMainGuild.code } : null,
+        mainPath: selectedMainPath ? { name: selectedMainPath.name } : null,
+        semiGuild: selectedSemiGuild ? { name: selectedSemiGuild.name, code: selectedSemiGuild.code } : null,
+        semiPath: selectedSemiPath ? { name: selectedSemiPath.name } : null,
+        words: selectedWords,
+        totalWordCost: totalCost,
+        finalSkills: finalSkills,
+        timestamp: new Date().toISOString() // Add timestamp for context
+    };
+}
+
+
+// --- Export Functions ---
+
+// Zmodyfikowana funkcja - teraz pobiera dane z getCurrentBuildData
 function exportToMarkdown() {
+    const buildData = getCurrentBuildData();
     let markdown = "# Podsumowanie Postaci Warlock MUD\n\n";
 
     // Sekcja Gildii Zawodowej
-    const guildSelect = document.getElementById('guildSelect');
-    const pathSelect = document.getElementById('pathSelect');
-    const racesAllowed = document.getElementById('racesAllowed').querySelector('p');
-    const activePlayers = document.getElementById('activePlayers').querySelector('p');
-
-    if (guildSelect.value) {
+    if (buildData.mainGuild) {
         markdown += "## Gildia Zawodowa\n";
-        markdown += `**Gildia:** ${guildSelect.options[guildSelect.selectedIndex].text}\n`;
-        if (pathSelect.value) {
-            markdown += `**Ścieżka:** ${pathSelect.value}\n`;
+        markdown += `**Gildia:** ${buildData.mainGuild.name} (${buildData.mainGuild.code})\n`;
+        if (buildData.mainPath) {
+            markdown += `**Ścieżka:** ${buildData.mainPath.name}\n`;
         }
-        if (racesAllowed && racesAllowed.textContent.includes(':')) {
-            markdown += `**Dozwolone rasy:** ${racesAllowed.textContent.split(': ')[1]}\n`;
-        } else if (racesAllowed) {
-            markdown += `**Dozwolone rasy:** ${racesAllowed.textContent}\n`;
+        // Add races and active players if needed (get from original data source based on code/path)
+        const guildInfo = (typeof guildsData !== 'undefined') ? guildsData.find(g => g.code === buildData.mainGuild.code) : null;
+        if (guildInfo && guildInfo.races) {
+            markdown += `**Dozwolone rasy:** ${formatRacesList(guildInfo.races)}\n`;
         }
-        if (activePlayers && activePlayers.textContent.includes(':')) {
-            markdown += `${activePlayers.textContent}\n`;
-        } else if (activePlayers) {
-            markdown += `${activePlayers.textContent}\n`;
+        const pathInfo = guildInfo && guildInfo.paths && buildData.mainPath ? guildInfo.paths.find(p => p.name === buildData.mainPath.name) : null;
+        if (pathInfo) {
+            markdown += `**Aktywni gracze:** ${pathInfo.activePlayers ?? '-'}\n`;
+            if (pathInfo.specs && pathInfo.specs.length > 0) {
+                markdown += `**Specjalne:** ${pathInfo.specs.join(', ')}\n`;
+            }
         }
+
         markdown += "\n";
     }
 
     // Sekcja Gildii Półzawodowej
-    const semiGuildSelect = document.getElementById('semiGuildSelect');
-    const semiPathSelect = document.getElementById('semiPathSelect');
-    const semiRacesAllowed = document.getElementById('semiRacesAllowed').querySelector('p');
-    const semiActivePlayers = document.getElementById('semiActivePlayers').querySelector('p');
-
-    if (semiGuildSelect.value) {
+    if (buildData.semiGuild) {
         markdown += "## Gildia Półzawodowa\n";
-        markdown += `**Gildia:** ${semiGuildSelect.options[semiGuildSelect.selectedIndex].text}\n`;
-        if (semiPathSelect.value) {
-            markdown += `**Ścieżka:** ${semiPathSelect.value}\n`;
+        markdown += `**Gildia:** ${buildData.semiGuild.name} (${buildData.semiGuild.code})\n`;
+        if (buildData.semiPath) {
+            markdown += `**Ścieżka:** ${buildData.semiPath.name}\n`;
         }
-        if (semiRacesAllowed && semiRacesAllowed.textContent.includes(':')) {
-            markdown += `**Dozwolone rasy:** ${semiRacesAllowed.textContent.split(': ')[1]}\n`;
-        } else if (semiRacesAllowed) {
-            markdown += `**Dozwolone rasy:** ${semiRacesAllowed.textContent}\n`;
+        const semiGuildInfo = (typeof semiGuildsData !== 'undefined') ? semiGuildsData.find(g => g.code === buildData.semiGuild.code) : null;
+        if (semiGuildInfo && semiGuildInfo.races) {
+            markdown += `**Dozwolone rasy:** ${formatRacesList(semiGuildInfo.races)}\n`;
         }
-        if (semiActivePlayers && semiActivePlayers.textContent.includes(':')) {
-            markdown += `${semiActivePlayers.textContent}\n`;
-        } else if (semiActivePlayers) {
-            markdown += `${semiActivePlayers.textContent}\n`;
+        const semiPathInfo = semiGuildInfo && semiGuildInfo.semipaths && buildData.semiPath ? semiGuildInfo.semipaths.find(p => p.name === buildData.semiPath.name) : null;
+        if (semiPathInfo) {
+            markdown += `**Aktywni gracze:** ${semiPathInfo.activePlayers ?? '-'}\n`;
+            if (semiPathInfo.specs && semiPathInfo.specs.length > 0) {
+                markdown += `**Specjalne:** ${semiPathInfo.specs.join(', ')}\n`;
+            }
         }
         markdown += "\n";
     }
 
     // Sekcja Wybranych Słów
-    const selectedWordsContainer = document.getElementById('wordsList');
-    const selectedWordCheckboxes = selectedWordsContainer.querySelectorAll('input[type="checkbox"]:checked + label');
-
-    if (selectedWordCheckboxes.length > 0) {
+    if (buildData.words.length > 0) {
         markdown += "## Wybrane Słowa\n";
-        selectedWordCheckboxes.forEach(label => {
-            markdown += `- ${label.textContent}\n`;
+        markdown += `**Łączny koszt:** ${buildData.totalWordCost}\n\n`;
+        buildData.words.forEach(word => {
+            markdown += `- **${word.name}** (${word.cost}): ${word.description}\n`;
         });
         markdown += "\n";
     }
 
-    // Sekcja Podsumowania Umiejętności (będzie wymagała dostosowania do Twojej implementacji)
-    const skillsSummary = document.getElementById('skillsSummary');
-    if (skillsSummary.textContent !== 'Wybierz gildię i ścieżkę, aby zobaczyć umiejętności.') {
+    // Sekcja Podsumowania Umiejętności
+    if (Object.keys(buildData.finalSkills).length > 0) {
         markdown += "## Podsumowanie Umiejętności\n";
-        markdown += skillsSummary.textContent + "\n\n"; // Może wymagać bardziej złożonego formatowania
+        const sortedSkills = Object.entries(buildData.finalSkills).sort(([, a], [, b]) => b - a); // Sort descending by value
+        sortedSkills.forEach(([skill, value]) => {
+            markdown += `- ${skill.charAt(0).toUpperCase() + skill.slice(1)}: ${value}\n`;
+        });
+        markdown += "\n";
     }
 
-    // Sekcja Efektów Wybranych Słów (będzie wymagała dostosowania do Twojej implementacji)
-    const effectsSummary = document.getElementById('effectsSummary');
-    if (effectsSummary.textContent !== 'Wybierz słowa, aby zobaczyć ich efekty.') {
-        markdown += "## Efekty Wybranych Słów\n";
-        markdown += effectsSummary.textContent + "\n\n"; // Może wymagać bardziej złożonego formatowania
-    }
+    // Trigger download
+    downloadFile(markdown, 'podsumowanie_postaci.md', 'text/markdown');
+}
 
-    const filename = 'podsumowanie_postaci.md';
-    const blob = new Blob([markdown], { type: 'text/markdown' });
+// NOWOŚĆ: Eksport do JSON
+function exportToJson() {
+    const buildData = getCurrentBuildData();
+    const jsonString = JSON.stringify(buildData, null, 2); // Pretty print JSON
+    downloadFile(jsonString, 'build_postaci.json', 'application/json');
+}
+
+// NOWOŚĆ: Helper do pobierania plików
+function downloadFile(content, filename, contentType) {
+    const blob = new Blob([content], { type: contentType });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;

--- a/slowa.js
+++ b/slowa.js
@@ -1,347 +1,505 @@
-        // Slowa Data Structure
-        const slowaData = [
-            { name: "wybraniec losu", cost: 10, description: "podnosi zauwazalnie prawdopodobienstwo zdobycia lepszych run (3)", effects: [{ type: "increase", stat: "prawdopodobienstwo zdobycia lepszych run", value: 3, intensity: "zauwazalnie" }] },
-            { name: "widzacy", cost: 10, description: "podnosi troche umiejetnosc w ocenianiu wlasnosci przedmiotow (20), troche umiejetnosc w szacowaniu wartosci przedmiotow (20) oraz sporo widzenie w ciemnosci (4) ponadto pozwala widziec magiczna energie (100)", effects: [
-                { type: "increase", stat: "umiejetnosc w ocenianiu wlasnosci przedmiotow", value: 20, intensity: "troche" },
-                { type: "increase", stat: "umiejetnosc w szacowaniu wartosci przedmiotow", value: 20, intensity: "troche" },
-                { type: "increase", stat: "widzenie w ciemnosci", value: 4, intensity: "sporo" },
-                { type: "special", description: "pozwala widziec magiczna energie", value: 100 }
-            ]},
-            { name: "leniuszek", cost: 20, description: "podnosi troche umiejetnosc w ocenianiu wlasnosci przedmiotow (20) ponadto juz nigdy nie bedziesz musial odwiedzac kowala (1)", effects: [
-                { type: "increase", stat: "umiejetnosc w ocenianiu wlasnosci przedmiotow", value: 20, intensity: "troche" },
-                { type: "special", description: "juz nigdy nie bedziesz musial odwiedzac kowala", value: 1 }
-            ]},
-            { name: "duzo wiecej", cost: 10, description: "podnosi zauwazalnie prawdopodobienstwo zdobycia dodatkowych run (150)", effects: [
-                { type: "increase", stat: "prawdopodobienstwo zdobycia dodatkowych run", value: 150, intensity: "zauwazalnie" }
-            ]},
-            { name: "jajoglowy", cost: 10, description: "podnosi sporo ilosc zapamietanych czarow (6) oraz nieco wielkosc listy dozwolonych czarow (3)", effects: [
-                { type: "increase", stat: "ilosc zapamietanych czarow", value: 6, intensity: "sporo" },
-                { type: "increase", stat: "wielkosc listy dozwolonych czarow", value: 3, intensity: "nieco" }
-            ]},
-            { name: "spekulant", cost: 20, description: "podnosi troche umiejetnosc w zawieraniu korzystnych transakcji handlowych (20)", effects: [
-                { type: "increase", stat: "umiejetnosc w zawieraniu korzystnych transakcji handlowych", value: 20, intensity: "troche" }
-            ]},
-            { name: "profesor", cost: 20, description: "podnosi nieznacznie ilosc doswiadczenia przekazywanego na inteligencje (1500) oraz nieznacznie ilosc doswiadczenia przekazywanego na madrosc (1500)", effects: [
-                { type: "increase", stat: "ilosc doswiadczenia przekazywanego na inteligencje", value: 1500, intensity: "nieznacznie" },
-                { type: "increase", stat: "ilosc doswiadczenia przekazywanego na madrosc", value: 1500, intensity: "nieznacznie" }
-            ]},
-            { name: "miesniak", cost: 20, description: "podnosi minimalnie ilosc doswiadczenia przekazywanego na sile (1000), minimalnie ilosc doswiadczenia przekazywanego na zrecznosc (1000) oraz minimalnie ilosc doswiadczenia przekazywanego na wytrzymalosc (1000)", effects: [
-                { type: "increase", stat: "ilosc doswiadczenia przekazywanego na sile", value: 1000, intensity: "minimalnie" },
-                { type: "increase", stat: "ilosc doswiadczenia przekazywanego na zrecznosc", value: 1000, intensity: "minimalnie" },
-                { type: "increase", stat: "ilosc doswiadczenia przekazywanego na wytrzymalosc", value: 1000, intensity: "minimalnie" }
-            ]},
-            { name: "heros", cost: 20, description: "podnosi nieznacznie ilosc doswiadczenia przekazywanego na odwage (2000)", effects: [
-                { type: "increase", stat: "ilosc doswiadczenia przekazywanego na odwage", value: 2000, intensity: "nieznacznie" }
-            ]},
-            { name: "kopacz", cost: 10, description: "podnosi troche umiejetnosc w wydobywaniu mineralow spod ziemi (20)", effects: [
-                { type: "increase", stat: "umiejetnosc w wydobywaniu mineralow spod ziemi", value: 20, intensity: "troche" }
-            ]},
-            { name: "wytapiacz", cost: 10, description: "podnosi troche umiejetnosc w metalurgii (20)", effects: [
-                { type: "increase", stat: "umiejetnosc w metalurgii", value: 20, intensity: "troche" }
-            ]},
-            { name: "kolekcjoner", cost: 20, description: "podnosi nieznacznie ilosc przedmiotow ktore mozesz trwale zabezpieczyc (1)", effects: [
-                { type: "increase", stat: "ilosc przedmiotow ktore mozesz trwale zabezpieczyc", value: 1, intensity: "nieznacznie" }
-            ]},
-            { name: "szczesciarz", cost: 10, description: "podnosi nieco prawdopodobienstwo zdobycia lepszych run (2)", effects: [
-                { type: "increase", stat: "prawdopodobienstwo zdobycia lepszych run", value: 2, intensity: "nieco" }
-            ]},
-            { name: "wiecej", cost: 10, description: "podnosi nieco prawdopodobienstwo zdobycia dodatkowych run (75)", effects: [
-                { type: "increase", stat: "prawdopodobienstwo zdobycia dodatkowych run", value: 75, intensity: "nieco" }
-            ]},
-            { name: "witalny", cost: 20, description: "podnosi ogromnie regeneracje kondycji (100)", effects: [
-                { type: "increase", stat: "regeneracje kondycji", value: 100, intensity: "ogromnie" }
-            ]},
-            { name: "uduchowiony", cost: 20, description: "podnosi minimalnie regeneracje many (5)", effects: [
-                { type: "increase", stat: "regeneracje many", value: 5, intensity: "minimalnie" }
-            ]},
-            { name: "niezmordowany", cost: 20, description: "podnosi troche regeneracje zmeczenia (40)", effects: [
-                { type: "increase", stat: "regeneracje zmeczenia", value: 40, intensity: "troche" }
-            ]},
-            { name: "farciarz", cost: 20, description: "podnosi zauwazalnie szczescie (50)", effects: [
-                { type: "increase", stat: "szczescie", value: 50, intensity: "zauwazalnie" }
-            ]},
-            { name: "silny", cost: 30, description: "podnosi nieznacznie sile (20)", effects: [
-                { type: "increase", stat: "sile", value: 20, intensity: "nieznacznie" }
-            ]},
-            { name: "zreczny", cost: 30, description: "podnosi nieznacznie zrecznosc (20)", effects: [
-                { type: "increase", stat: "zrecznosc", value: 20, intensity: "nieznacznie" }
-            ]},
-            { name: "wytrzymaly", cost: 30, description: "podnosi nieznacznie wytrzymalosc (20)", effects: [
-                { type: "increase", stat: "wytrzymalosc", value: 20, intensity: "nieznacznie" }
-            ]},
-            { name: "inteligentny", cost: 30, description: "podnosi nieznacznie inteligencje (20)", effects: [
-                { type: "increase", stat: "inteligencje", value: 20, intensity: "nieznacznie" }
-            ]},
-            { name: "madry", cost: 30, description: "podnosi nieznacznie madrosc (20)", effects: [
-                { type: "increase", stat: "madrosc", value: 20, intensity: "nieznacznie" }
-            ]},
-            { name: "odwazny", cost: 30, description: "podnosi nieznacznie odwage (20)", effects: [
-                { type: "increase", stat: "odwage", value: 20, intensity: "nieznacznie" }
-            ]},
-            { name: "szampierz", cost: 30, description: "podnosi nieznacznie umiejetnosci walki wszystkimi bronmi (10)", effects: [
-                { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "karateka", cost: 30, description: "podnosi nieznacznie umiejetnosc w walce bez broni (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w walce bez broni", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "patelnia", cost: 30, description: "podnosi nieznacznie umiejetnosc w skutecznym uzywaniu tarczy (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "lewak", cost: 30, description: "podnosi nieznacznie umiejetnosc w parowaniu ciosow przeciwnika (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "wicher", cost: 30, description: "podnosi nieznacznie umiejetnosc w unikaniu ciosow przeciwnika (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "tancerz", cost: 30, description: "podnosi nieznacznie umiejetnosc w walce dwiema bronmi jednoczesnie (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w walce dwiema bronmi jednoczesnie", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "koniuszy", cost: 30, description: "podnosi troche umiejetnosc w walce z konskiego grzbietu (20)", effects: [
-                { type: "increase", stat: "umiejetnosc w walce z konskiego grzbietu", value: 20, intensity: "troche" }
-            ]},
-            { name: "przyboczny", cost: 30, description: "podnosi troche umiejetnosc w walce w szyku (20)", effects: [
-                { type: "increase", stat: "umiejetnosc w walce w szyku", value: 20, intensity: "troche" }
-            ]},
-            { name: "przywodca", cost: 30, description: "podnosi troche umiejetnosc w wywieraniu wplywu na innych (20)", effects: [
-                { type: "increase", stat: "umiejetnosc w wywieraniu wplywu na innych", value: 20, intensity: "troche" }
-            ]},
-            { name: "ogien", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia ognia (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia ognia", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "powietrze", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia powietrza (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia powietrza", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "ziemia", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia ziemi (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia ziemi", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "woda", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia wody (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia wody", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "zycie", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia zycia (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia zycia", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "smierc", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia mroku (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia mroku", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "przemiana", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia przemiany (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia przemiany", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "mistycyzm", cost: 30, description: "podnosi nieznacznie umiejetnosc w mistycyzmie (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w mistycyzmie", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "zaklinanie", cost: 30, description: "podnosi nieznacznie umiejetnosc w zaklinaniu (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w zaklinaniu", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "przywolywanie", cost: 30, description: "podnosi nieznacznie umiejetnosc w magii tworzenia i przywolywania (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w magii tworzenia i przywolywania", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "iluzja", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia iluzji (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia iluzji", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "rozpraszanie", cost: 30, description: "podnosi nieznacznie umiejetnosc w rozpraszaniu zaklec (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w rozpraszaniu zaklec", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "czarodziejstwo", cost: 30, description: "podnosi nieznacznie umiejetnosc w znajomosci i uzywaniu magii (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w znajomosci i uzywaniu magii", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "runy", cost: 30, description: "podnosi nieznacznie umiejetnosc w pisaniu i uzywaniu run (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w pisaniu i uzywaniu run", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "koncentracja", cost: 30, description: "podnosi nieznacznie umiejetnosc w koncentrowaniu swoich magicznych zdolnosci (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "waleczny spokoj", cost: 30, description: "podnosi troche umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki (20)", effects: [
-                { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki", value: 20, intensity: "troche" }
-            ]},
-            { name: "wojownik", cost: 50, description: "pozwala trenowac umiejetnosci walki wszystkimi bronmi na poprawnie (60), pozwala trenowac umiejetnosc w skutecznym uzywaniu tarczy na znosnie (45), pozwala trenowac umiejetnosc w parowaniu ciosow przeciwnika na znosnie (45) oraz pozwala trenowac umiejetnosc w unikaniu ciosow przeciwnika na znosnie (45)", effects: [
-                { type: "special", description: "pozwala trenowac umiejetnosci walki wszystkimi bronmi na poprawnie", value: 60 },
-                { type: "special", description: "pozwala trenowac umiejetnosc w skutecznym uzywaniu tarczy na znosnie", value: 45 },
-                { type: "special", description: "pozwala trenowac umiejetnosc w parowaniu ciosow przeciwnika na znosnie", value: 45 },
-                { type: "special", description: "pozwala trenowac umiejetnosc w unikaniu ciosow przeciwnika na znosnie", value: 45 }
-            ]},
-            { name: "mag", cost: 50, description: "pozwala trenowac umiejetnosci ze wszystkich szkol magii na powierzchownie (40), pozwala trenowac umiejetnosc w koncentrowaniu swoich magicznych zdolnosci na poprawnie (60) oraz pozwala trenowac umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki na znosnie (50)", effects: [
-                { type: "special", description: "pozwala trenowac umiejetnosci ze wszystkich szkol magii na powierzchownie", value: 40 },
-                { type: "special", description: "pozwala trenowac umiejetnosc w koncentrowaniu swoich magicznych zdolnosci na poprawnie", value: 60 },
-                { type: "special", description: "pozwala trenowac umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki na znosnie", value: 50 }
-            ]},
-            { name: "galop", cost: 40, description: "podnosi zauwazalnie umiejetnosc w jezdzie konnej (25), sporo umiejetnosc w walce z konskiego grzbietu (30) oraz nieznacznie umiejetnosci walki wszystkimi bronmi (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w jezdzie konnej", value: 25, intensity: "zauwazalnie" },
-                { type: "increase", stat: "umiejetnosc w walce z konskiego grzbietu", value: 30, intensity: "sporo" },
-                { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 10, intensity: "nieznacznie" }
-            ]},
-			{ name: "mikstura", cost: 40, description: "podnosi troche umiejetnosc w warzeniu i rozpoznawaniu mikstur (20), troche umiejetnosc w znajdowaniu i rozpoznawaniu ziol (20) oraz nieznacznie umiejetnosc w poslugiwaniu sie magia przemiany (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w warzeniu i rozpoznawaniu mikstur", value: 20, intensity: "troche" },
-                { type: "increase", stat: "umiejetnosc w znajdowaniu i rozpoznawaniu ziol", value: 20, intensity: "troche" },
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia przemiany", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "berserker", cost: 40, description: "podnosi troche umiejetnosci walki wszystkimi bronmi (20) oraz troche umiejetnosc w walce bez broni (20) natomiast obniza nieznacznie umiejetnosc w unikaniu ciosow przeciwnika (-10), nieznacznie umiejetnosc w parowaniu ciosow przeciwnika (-10), nieznacznie umiejetnosc w skutecznym uzywaniu tarczy (-10) oraz minimalnie wytrzymalosc (-10)", effects: [
-                { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 20, intensity: "troche" },
-                { type: "increase", stat: "umiejetnosc w walce bez broni", value: 20, intensity: "troche" },
-                { type: "decrease", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: -10, intensity: "nieznacznie" },
-                { type: "decrease", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: -10, intensity: "nieznacznie" },
-                { type: "decrease", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: -10, intensity: "nieznacznie" },
-                { type: "decrease", stat: "wytrzymalosc", value: -10, intensity: "minimalnie" }
-            ]},
-            { name: "barbarzynca", cost: 40, description: "podnosi nieco umiejetnosci walki wszystkimi bronmi (15), nieco umiejetnosc w walce bez broni (15), minimalnie umiejetnosc w unikaniu ciosow przeciwnika (5), minimalnie umiejetnosc w parowaniu ciosow przeciwnika (5) oraz minimalnie umiejetnosc w skutecznym uzywaniu tarczy (5) ponadto blokuje uzywanie jakiekolwiek magii", effects: [
-                { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 15, intensity: "nieco" },
-                { type: "increase", stat: "umiejetnosc w walce bez broni", value: 15, intensity: "nieco" },
-                { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 5, intensity: "minimalnie" },
-                { type: "special", description: "blokuje uzywanie jakiekolwiek magii" }
-            ]},
-            { name: "mag bojowy", cost: 40, description: "podnosi minimalnie umiejetnosci walki wszystkimi bronmi (5), nieco umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki (15), minimalnie umiejetnosc w unikaniu ciosow przeciwnika (5), minimalnie umiejetnosc w parowaniu ciosow przeciwnika (5) oraz minimalnie umiejetnosc w skutecznym uzywaniu tarczy (5) natomiast obniza nieco wplyw wagi zbroi na czarowanie (-25)", effects: [
-                { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki", value: 15, intensity: "nieco" },
-                { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 5, intensity: "minimalnie" },
-                { type: "decrease", stat: "wplyw wagi zbroi na czarowanie", value: -25, intensity: "nieco" }
-            ]},
-            { name: "tarczownik", cost: 40, description: "podnosi nieco umiejetnosc w unikaniu ciosow przeciwnika (15), nieco umiejetnosc w parowaniu ciosow przeciwnika (15), nieco umiejetnosc w skutecznym uzywaniu tarczy (15), nieco umiejetnosc w walce w szyku (15) oraz nieco maksymalna kondycje (1000) natomiast obniza minimalnie umiejetnosci walki wszystkimi bronmi (-5) oraz minimalnie umiejetnosc w walce bez broni (-5)", effects: [
-                { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 15, intensity: "nieco" },
-                { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 15, intensity: "nieco" },
-                { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 15, intensity: "nieco" },
-                { type: "increase", stat: "umiejetnosc w walce w szyku", value: 15, intensity: "nieco" },
-                { type: "increase", stat: "maksymalna kondycje", value: 1000, intensity: "nieco" },
-                { type: "decrease", stat: "umiejetnosci walki wszystkimi bronmi", value: -5, intensity: "minimalnie" },
-                { type: "decrease", stat: "umiejetnosc w walce bez broni", value: -5, intensity: "minimalnie" }
-            ]},
-            { name: "celny", cost: 40, description: "podnosi nieznacznie umiejetnosc w walce dwiema bronmi jednoczesnie (10) oraz nieznacznie ilosc obrazen ktore pomijaja zbroje (20)", effects: [
-                { type: "increase", stat: "umiejetnosc w walce dwiema bronmi jednoczesnie", value: 10, intensity: "nieznacznie" },
-                { type: "increase", stat: "ilosc obrazen ktore pomijaja zbroje", value: 20, intensity: "nieznacznie" }
-            ]},
-            { name: "szybki", cost: 40, description: "podnosi minimalnie zrecznosc (10) oraz nieznacznie szybkosc wyprowadzanych atakow (20) natomiast obniza minimalnie sile (-10) oraz nieznacznie umiejetnosc w wyczuwaniu slabosci wroga (-10)", effects: [
-                { type: "increase", stat: "zrecznosc", value: 10, intensity: "minimalnie" },
-                { type: "increase", stat: "szybkosc wyprowadzanych atakow", value: 20, intensity: "nieznacznie" },
-                { type: "decrease", stat: "sile", value: -10, intensity: "minimalnie" },
-                { type: "decrease", stat: "umiejetnosc w wyczuwaniu slabosci wroga", value: -10, intensity: "nieznacznie" }
-            ]},
-            { name: "silacz", cost: 40, description: "podnosi minimalnie umiejetnosc w walce dwiema bronmi jednoczesnie (5) oraz nieznacznie regeneracje zmeczenia (15) ponadto pozwala dobywac dwureczne bronie jedna reka (2)", effects: [
-                { type: "increase", stat: "umiejetnosc w walce dwiema bronmi jednoczesnie", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "regeneracje zmeczenia", value: 15, intensity: "nieznacznie" },
-                { type: "special", description: "pozwala dobywac dwureczne bronie jedna reka", value: 2 }
-            ]},
-            { name: "mesmer", cost: 40, description: "podnosi nieznacznie umiejetnosc w koncentrowaniu swoich magicznych zdolnosci (10), minimalnie umiejetnosci ze wszystkich szkol magii (5) oraz nieznacznie maksymalna mane (300)", effects: [
-                { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci", value: 10, intensity: "nieznacznie" },
-                { type: "increase", stat: "umiejetnosci ze wszystkich szkol magii", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "maksymalna mane", value: 300, intensity: "nieznacznie" }
-            ]},
-            { name: "specjalista", cost: 40, description: "podnosi nieznacznie ilosc wyprowadzanych atakow specjalnych (15)", effects: [
-                { type: "increase", stat: "ilosc wyprowadzanych atakow specjalnych", value: 15, intensity: "nieznacznie" }
-            ]},
-            { name: "kaplan bitewny", cost: 40, description: "podnosi minimalnie umiejetnosc w poslugiwaniu sie magia zycia (5), nieznacznie umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki (10), minimalnie umiejetnosc w unikaniu ciosow przeciwnika (5), minimalnie umiejetnosc w parowaniu ciosow przeciwnika (5) oraz minimalnie umiejetnosc w skutecznym uzywaniu tarczy (5) ponadto pozwala uzywac tarczy, parowac i unikac podczas czarowania (1)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia zycia", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki", value: 10, intensity: "nieznacznie" },
-                { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 5, intensity: "minimalnie" },
-                { type: "special", description: "pozwala uzywac tarczy, parowac i unikac podczas czarowania", value: 1 }
-            ]},
-            { name: "zdrada", cost: 10, description: "podnosi minimalnie inteligencje (5) ponadto zamienia ze soba umiejetnosci w poslugiwaniu sie magia zycia i w poslugiwaniu sie magia mroku", effects: [
-                { type: "increase", stat: "inteligencje", value: 5, intensity: "minimalnie" },
-                { type: "special", description: "zamienia ze soba umiejetnosci w poslugiwaniu sie magia zycia i w poslugiwaniu sie magia mroku" }
-            ]},
-            { name: "podmiana", cost: 10, description: "podnosi minimalnie sile (5) ponadto zamienia ze soba umiejetnosci w skutecznym uzywaniu tarczy i w walce dwiema bronmi jednoczesnie", effects: [
-                { type: "increase", stat: "sile", value: 5, intensity: "minimalnie" },
-                { type: "special", description: "zamienia ze soba umiejetnosci w skutecznym uzywaniu tarczy i w walce dwiema bronmi jednoczesnie" }
-            ]},
-            { name: "bestia", cost: 40, description: "podnosi nieznacznie umiejetnosc w walce bez broni (10) oraz nieznacznie umiejetnosc w poslugiwaniu sie magia przemiany (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w walce bez broni", value: 10, intensity: "nieznacznie" },
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia przemiany", value: 10, intensity: "nieznacznie" }
-            ]},
-            { name: "wladca bestii", cost: 40, description: "podnosi nieznacznie umiejetnosc w magii tworzenia i przywolywania (10) natomiast obniza troche ilosc many potrzebna do utrzymania przywolancow (-35) ponadto pozwala przywolac jednego dodatkowego, innego niz juz wezwany przywolanca (1)", effects: [
-                { type: "increase", stat: "umiejetnosc w magii tworzenia i przywolywania", value: 10, intensity: "nieznacznie" },
-                { type: "decrease", stat: "ilosc many potrzebna do utrzymania przywolancow", value: -35, intensity: "troche" },
-                { type: "special", description: "pozwala przywolac jednego dodatkowego, innego niz juz wezwany przywolanca", value: 1 }
-            ]},
-            { name: "kaznodzieja", cost: 40, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia zycia (10), nieznacznie umiejetnosc w mistycyzmie (10), minimalnie madrosc (10), nieznacznie odpornosc na obrazenia magii smierci (10) oraz minimalnie sile czarow leczacych (10)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia zycia", value: 10, intensity: "nieznacznie" },
-                { type: "increase", stat: "umiejetnosc w mistycyzmie", value: 10, intensity: "nieznacznie" },
-                { type: "increase", stat: "madrosc", value: 10, intensity: "minimalnie" },
-                { type: "increase", stat: "odpornosc na obrazenia magii smierci", value: 10, intensity: "nieznacznie" },
-                { type: "increase", stat: "sile czarow leczacych", value: 10, intensity: "minimalnie" }
-            ]},
-            { name: "sila smoka", cost: 60, description: "laczy ducha wlasciciela z duchem pradawnego smoka", effects: [
-                { type: "special", description: "laczy ducha wlasciciela z duchem pradawnego smoka" }
-            ]},
-            { name: "ciezkozbrojny", cost: 40, description: "podnosi minimalnie sile (5), minimalnie umiejetnosci walki wszystkimi bronmi (5) oraz minimalnie umiejetnosc w skutecznym uzywaniu tarczy (5) natomiast obniza zauwazalnie wplyw przeciazenia na zmeczenie w walce (-50)", effects: [
-                { type: "increase", stat: "sile", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 5, intensity: "minimalnie" },
-                { type: "decrease", stat: "wplyw przeciazenia na zmeczenie w walce", value: -50, intensity: "zauwazalnie" }
-            ]},
-            { name: "wladca ciemnosci", cost: 40, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia mroku (10) natomiast obniza troche ilosc many potrzebna do utrzymania przywolancow (-35) ponadto pozwala przywolac jednego dodatkowego, innego niz juz wezwany przywolanca (1)", effects: [
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia mroku", value: 10, intensity: "nieznacznie" },
-                { type: "decrease", stat: "ilosc many potrzebna do utrzymania przywolancow", value: -35, intensity: "troche" },
-                { type: "special", description: "pozwala przywolac jednego dodatkowego, innego niz juz wezwany przywolanca", value: 1 }
-            ]},
-            { name: "kamiennoskory", cost: 40, description: "podnosi nieco odpornosc na obrazenia klute (18), nieco odpornosc na obrazenia ciete (18) oraz nieco odpornosc na obrazenia obuchowe (18)", effects: [
-                { type: "increase", stat: "odpornosc na obrazenia klute", value: 18, intensity: "nieco" },
-                { type: "increase", stat: "odpornosc na obrazenia ciete", value: 18, intensity: "nieco" },
-                { type: "increase", stat: "odpornosc na obrazenia obuchowe", value: 18, intensity: "nieco" }
-            ]},
-            { name: "antymagia", cost: 40, description: "podnosi zauwazalnie odpornosc na obrazenia magii powietrza (40), zauwazalnie odpornosc na obrazenia magii ziemi (40), zauwazalnie odpornosc na obrazenia magii ognia (40), zauwazalnie odpornosc na obrazenia magii wody (40), zauwazalnie odpornosc na obrazenia magii zycia (40) oraz zauwazalnie odpornosc na obrazenia magii smierci (40)", effects: [
-                { type: "increase", stat: "odpornosc na obrazenia magii powietrza", value: 40, intensity: "zauwazalnie" },
-                { type: "increase", stat: "odpornosc na obrazenia magii ziemi", value: 40, intensity: "zauwazalnie" },
-                { type: "increase", stat: "odpornosc na obrazenia magii ognia", value: 40, intensity: "zauwazalnie" },
-                { type: "increase", stat: "odpornosc na obrazenia magii wody", value: 40, intensity: "zauwazalnie" },
-                { type: "increase", stat: "odpornosc na obrazenia magii zycia", value: 40, intensity: "zauwazalnie" },
-                { type: "increase", stat: "odpornosc na obrazenia magii smierci", value: 40, intensity: "zauwazalnie" }
-            ]},
-            { name: "lekkozbrojny", cost: 40, description: "podnosi minimalnie zrecznosc (5), minimalnie umiejetnosci walki wszystkimi bronmi (5), minimalnie umiejetnosc w unikaniu ciosow przeciwnika (5), ogromnie wplyw przeciazenia na zmeczenie w walce (100), bardzo ilosc przeciwnikow z ktorymi mozemy walczyc bez utraty sprawnosci (4) oraz minimalnie ilosc obrazen ktore pomijaja zbroje (10)", effects: [
-                { type: "increase", stat: "zrecznosc", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "wplyw przeciazenia na zmeczenie w walce", value: 100, intensity: "ogromnie" },
-                { type: "increase", stat: "ilosc przeciwnikow z ktorymi mozemy walczyc bez utraty sprawnosci", value: 4, intensity: "bardzo" },
-                { type: "increase", stat: "ilosc obrazen ktore pomijaja zbroje", value: 10, intensity: "minimalnie" }
-            ]},
-            { name: "mistrz harmonii", cost: 40, description: "podnosi minimalnie sile czarow wzmacniajacych (5) oraz minimalnie sile czarow oslabiajacych (5) natomiast obniza nieco ilosc many potrzebna do utrzymania aur (-30) ponadto pozwala utrzymywac jedna dodatkowa aure (1)", effects: [
-                { type: "increase", stat: "sile czarow wzmacniajacych", value: 5, intensity: "minimalnie" },
-                { type: "increase", stat: "sile czarow oslabiajacych", value: 5, intensity: "minimalnie" },
-                { type: "decrease", stat: "ilosc many potrzebna do utrzymania aur", value: -30, intensity: "nieco" },
-                { type: "special", description: "pozwala utrzymywac jedna dodatkowa aure", value: 1 }
-            ]},
-            { name: "przewrotnosc", cost: 10, description: "podnosi minimalnie zrecznosc (5) ponadto zamienia ze soba umiejetnosci w parowaniu ciosow przeciwnika i w unikaniu ciosow przeciwnika", effects: [
-                { type: "increase", stat: "zrecznosc", value: 5, intensity: "minimalnie" },
-                { type: "special", description: "zamienia ze soba umiejetnosci w parowaniu ciosow przeciwnika i w unikaniu ciosow przeciwnika" }
-            ]},
-            { name: "wszechstronny", cost: 40, description: "podnosi zauwazalnie wielkosc listy dozwolonych czarow (5), nieznacznie umiejetnosc w poslugiwaniu sie magia ognia (8), nieznacznie umiejetnosc w poslugiwaniu sie magia wody (8), nieznacznie umiejetnosc w poslugiwaniu sie magia ziemi (8) oraz nieznacznie umiejetnosc w poslugiwaniu sie magia powietrza (8) natomiast obniza troche koszt czarow (-40), nieco szybkosc odnawiania czarow (-100) oraz minimalnie szybkosc czarowania (-10)", effects: [
-                { type: "increase", stat: "wielkosc listy dozwolonych czarow", value: 5, intensity: "zauwazalnie" },
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia ognia", value: 8, intensity: "nieznacznie" },
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia wody", value: 8, intensity: "nieznacznie" },
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia ziemi", value: 8, intensity: "nieznacznie" },
-                { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia powietrza", value: 8, intensity: "nieznacznie" },
-                { type: "decrease", stat: "koszt czarow", value: -40, intensity: "troche" },
-                { type: "decrease", stat: "szybkosc odnawiania czarow", value: -100, intensity: "nieco" },
-                { type: "decrease", stat: "szybkosc czarowania", value: -10, intensity: "minimalnie" }
-            ]},
-            { name: "wampir", cost: 40, description: "podnosi troche ilosc zycia wykradanego przy atakach (40) ponadto sprawia ze nie mozesz byc magicznie uleczony (1)", effects: [
-                { type: "increase", stat: "ilosc zycia wykradanego przy atakach", value: 40, intensity: "troche" },
-                { type: "special", description: "sprawia ze nie mozesz byc magicznie uleczony", value: 1 }
-            ]},
-            { name: "sama magia", cost: 40, description: "podnosi minimalnie szybkosc odnawiania czarow (20) oraz minimalnie szybkosc czarowania (20) natomiast obniza nieznacznie koszt czarow (-15), ogromnie szybkosc wyprowadzanych atakow (-1000) oraz ogromnie ilosc wyprowadzanych atakow specjalnych (-1000)", effects: [
-                { type: "increase", stat: "szybkosc odnawiania czarow", value: 20, intensity: "minimalnie" },
-                { type: "increase", stat: "szybkosc czarowania", value: 20, intensity: "minimalnie" },
-                { type: "decrease", stat: "koszt czarow", value: -15, intensity: "nieznacznie" },
-                { type: "decrease", stat: "szybkosc wyprowadzanych atakow", value: -1000, intensity: "ogromnie" },
-                { type: "decrease", stat: "ilosc wyprowadzanych atakow specjalnych", value: -1000, intensity: "ogromnie" }
-            ]},
-            { name: "cien", cost: 40, description: "podnosi nieznacznie ilosc obrazen ktore pomijaja odpornosci (20), nieco ilosc obrazen ktore pomijaja zbroje (30), ogromnie wplyw wagi zbroi na szybkosc walki (100) oraz ogromnie wplyw wagi zbroi na czarowanie (500) natomiast obniza nieco odpornosc na obrazenia klute (-25), nieco odpornosc na obrazenia ciete (-25), nieco odpornosc na obrazenia obuchowe (-25), nieco odpornosc na obrazenia magii powietrza (-25), nieco odpornosc na obrazenia magii ziemi (-25), nieco odpornosc na obrazenia magii ognia (-25), nieco odpornosc na obrazenia magii wody (-25), nieco odpornosc na obrazenia magii zycia (-25) oraz nieco odpornosc na obrazenia magii smierci (-25)", effects: [
-                { type: "increase", stat: "ilosc obrazen ktore pomijaja odpornosci", value: 20, intensity: "nieznacznie" },
-                { type: "increase", stat: "ilosc obrazen ktore pomijaja zbroje", value: 30, intensity: "nieco" },
-                { type: "increase", stat: "wplyw wagi zbroi na szybkosc walki", value: 100, intensity: "ogromnie" },
-                { type: "increase", stat: "wplyw wagi zbroi na czarowanie", value: 500, intensity: "ogromnie" },
-                { type: "decrease", stat: "odpornosc na obrazenia klute", value: -25, intensity: "nieco" },
-                { type: "decrease", stat: "odpornosc na obrazenia ciete", value: -25, intensity: "nieco" },
-                { type: "decrease", stat: "odpornosc na obrazenia obuchowe", value: -25, intensity: "nieco" },
-                { type: "decrease", stat: "odpornosc na obrazenia magii powietrza", value: -25, intensity: "nieco" },
-                { type: "decrease", stat: "odpornosc na obrazenia magii ziemi", value: -25, intensity: "nieco" },
-                { type: "decrease", stat: "odpornosc na obrazenia magii ognia", value: -25, intensity: "nieco" },
-                { type: "decrease", stat: "odpornosc na obrazenia magii wody", value: -25, intensity: "nieco" },
-                { type: "decrease", stat: "odpornosc na obrazenia magii zycia", value: -25, intensity: "nieco" },
-                { type: "decrease", stat: "odpornosc na obrazenia magii smierci", value: -25, intensity: "nieco" }
-            ]},
-            // Dodaj więcej słów według potrzeb
-	];
+// Slowa Data Structure
+const slowaData = [
+    { name: "wybraniec losu", cost: 10, description: "podnosi zauwazalnie prawdopodobienstwo zdobycia lepszych run (3)", effects: [{ type: "increase", stat: "prawdopodobienstwo zdobycia lepszych run", value: 3, intensity: "zauwazalnie" }] },
+    {
+        name: "widzacy", cost: 10, description: "podnosi troche umiejetnosc w ocenianiu wlasnosci przedmiotow (20), troche umiejetnosc w szacowaniu wartosci przedmiotow (20) oraz sporo widzenie w ciemnosci (4) ponadto pozwala widziec magiczna energie (100)", effects: [
+            { type: "increase", stat: "umiejetnosc w ocenianiu wlasnosci przedmiotow", value: 20, intensity: "troche" },
+            { type: "increase", stat: "umiejetnosc w szacowaniu wartosci przedmiotow", value: 20, intensity: "troche" },
+            { type: "increase", stat: "widzenie w ciemnosci", value: 4, intensity: "sporo" },
+            { type: "special", description: "pozwala widziec magiczna energie", value: 100 }
+        ]
+    },
+    {
+        name: "leniuszek", cost: 20, description: "podnosi troche umiejetnosc w ocenianiu wlasnosci przedmiotow (20) ponadto juz nigdy nie bedziesz musial odwiedzac kowala (1)", effects: [
+            { type: "increase", stat: "umiejetnosc w ocenianiu wlasnosci przedmiotow", value: 20, intensity: "troche" },
+            { type: "special", description: "juz nigdy nie bedziesz musial odwiedzac kowala", value: 1 }
+        ]
+    },
+    {
+        name: "duzo wiecej", cost: 10, description: "podnosi zauwazalnie prawdopodobienstwo zdobycia dodatkowych run (150)", effects: [
+            { type: "increase", stat: "prawdopodobienstwo zdobycia dodatkowych run", value: 150, intensity: "zauwazalnie" }
+        ]
+    },
+    {
+        name: "jajoglowy", cost: 10, description: "podnosi sporo ilosc zapamietanych czarow (6) oraz nieco wielkosc listy dozwolonych czarow (3)", effects: [
+            { type: "increase", stat: "ilosc zapamietanych czarow", value: 6, intensity: "sporo" },
+            { type: "increase", stat: "wielkosc listy dozwolonych czarow", value: 3, intensity: "nieco" }
+        ]
+    },
+    {
+        name: "spekulant", cost: 20, description: "podnosi troche umiejetnosc w zawieraniu korzystnych transakcji handlowych (20)", effects: [
+            { type: "increase", stat: "umiejetnosc w zawieraniu korzystnych transakcji handlowych", value: 20, intensity: "troche" }
+        ]
+    },
+    {
+        name: "profesor", cost: 20, description: "podnosi nieznacznie ilosc doswiadczenia przekazywanego na inteligencje (1500) oraz nieznacznie ilosc doswiadczenia przekazywanego na madrosc (1500)", effects: [
+            { type: "increase", stat: "ilosc doswiadczenia przekazywanego na inteligencje", value: 1500, intensity: "nieznacznie" },
+            { type: "increase", stat: "ilosc doswiadczenia przekazywanego na madrosc", value: 1500, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "miesniak", cost: 20, description: "podnosi minimalnie ilosc doswiadczenia przekazywanego na sile (1000), minimalnie ilosc doswiadczenia przekazywanego na zrecznosc (1000) oraz minimalnie ilosc doswiadczenia przekazywanego na wytrzymalosc (1000)", effects: [
+            { type: "increase", stat: "ilosc doswiadczenia przekazywanego na sile", value: 1000, intensity: "minimalnie" },
+            { type: "increase", stat: "ilosc doswiadczenia przekazywanego na zrecznosc", value: 1000, intensity: "minimalnie" },
+            { type: "increase", stat: "ilosc doswiadczenia przekazywanego na wytrzymalosc", value: 1000, intensity: "minimalnie" }
+        ]
+    },
+    {
+        name: "heros", cost: 20, description: "podnosi nieznacznie ilosc doswiadczenia przekazywanego na odwage (2000)", effects: [
+            { type: "increase", stat: "ilosc doswiadczenia przekazywanego na odwage", value: 2000, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "kopacz", cost: 10, description: "podnosi troche umiejetnosc w wydobywaniu mineralow spod ziemi (20)", effects: [
+            { type: "increase", stat: "umiejetnosc w wydobywaniu mineralow spod ziemi", value: 20, intensity: "troche" }
+        ]
+    },
+    {
+        name: "wytapiacz", cost: 10, description: "podnosi troche umiejetnosc w metalurgii (20)", effects: [
+            { type: "increase", stat: "umiejetnosc w metalurgii", value: 20, intensity: "troche" }
+        ]
+    },
+    {
+        name: "kolekcjoner", cost: 20, description: "podnosi nieznacznie ilosc przedmiotow ktore mozesz trwale zabezpieczyc (1)", effects: [
+            { type: "increase", stat: "ilosc przedmiotow ktore mozesz trwale zabezpieczyc", value: 1, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "szczesciarz", cost: 10, description: "podnosi nieco prawdopodobienstwo zdobycia lepszych run (2)", effects: [
+            { type: "increase", stat: "prawdopodobienstwo zdobycia lepszych run", value: 2, intensity: "nieco" }
+        ]
+    },
+    {
+        name: "wiecej", cost: 10, description: "podnosi nieco prawdopodobienstwo zdobycia dodatkowych run (75)", effects: [
+            { type: "increase", stat: "prawdopodobienstwo zdobycia dodatkowych run", value: 75, intensity: "nieco" }
+        ]
+    },
+    {
+        name: "witalny", cost: 20, description: "podnosi ogromnie regeneracje kondycji (100)", effects: [
+            { type: "increase", stat: "regeneracje kondycji", value: 100, intensity: "ogromnie" }
+        ]
+    },
+    {
+        name: "uduchowiony", cost: 20, description: "podnosi minimalnie regeneracje many (5)", effects: [
+            { type: "increase", stat: "regeneracje many", value: 5, intensity: "minimalnie" }
+        ]
+    },
+    {
+        name: "niezmordowany", cost: 20, description: "podnosi troche regeneracje zmeczenia (40)", effects: [
+            { type: "increase", stat: "regeneracje zmeczenia", value: 40, intensity: "troche" }
+        ]
+    },
+    {
+        name: "farciarz", cost: 20, description: "podnosi zauwazalnie szczescie (50)", effects: [
+            { type: "increase", stat: "szczescie", value: 50, intensity: "zauwazalnie" }
+        ]
+    },
+    {
+        name: "silny", cost: 30, description: "podnosi nieznacznie sile (20)", effects: [
+            { type: "increase", stat: "sile", value: 20, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "zreczny", cost: 30, description: "podnosi nieznacznie zrecznosc (20)", effects: [
+            { type: "increase", stat: "zrecznosc", value: 20, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "wytrzymaly", cost: 30, description: "podnosi nieznacznie wytrzymalosc (20)", effects: [
+            { type: "increase", stat: "wytrzymalosc", value: 20, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "inteligentny", cost: 30, description: "podnosi nieznacznie inteligencje (20)", effects: [
+            { type: "increase", stat: "inteligencje", value: 20, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "madry", cost: 30, description: "podnosi nieznacznie madrosc (20)", effects: [
+            { type: "increase", stat: "madrosc", value: 20, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "odwazny", cost: 30, description: "podnosi nieznacznie odwage (20)", effects: [
+            { type: "increase", stat: "odwage", value: 20, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "szampierz", cost: 30, description: "podnosi nieznacznie umiejetnosci walki wszystkimi bronmi (10)", effects: [
+            { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "karateka", cost: 30, description: "podnosi nieznacznie umiejetnosc w walce bez broni (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w walce bez broni", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "patelnia", cost: 30, description: "podnosi nieznacznie umiejetnosc w skutecznym uzywaniu tarczy (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "lewak", cost: 30, description: "podnosi nieznacznie umiejetnosc w parowaniu ciosow przeciwnika (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "wicher", cost: 30, description: "podnosi nieznacznie umiejetnosc w unikaniu ciosow przeciwnika (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "tancerz", cost: 30, description: "podnosi nieznacznie umiejetnosc w walce dwiema bronmi jednoczesnie (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w walce dwiema bronmi jednoczesnie", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "koniuszy", cost: 30, description: "podnosi troche umiejetnosc w walce z konskiego grzbietu (20)", effects: [
+            { type: "increase", stat: "umiejetnosc w walce z konskiego grzbietu", value: 20, intensity: "troche" }
+        ]
+    },
+    {
+        name: "przyboczny", cost: 30, description: "podnosi troche umiejetnosc w walce w szyku (20)", effects: [
+            { type: "increase", stat: "umiejetnosc w walce w szyku", value: 20, intensity: "troche" }
+        ]
+    },
+    {
+        name: "przywodca", cost: 30, description: "podnosi troche umiejetnosc w wywieraniu wplywu na innych (20)", effects: [
+            { type: "increase", stat: "umiejetnosc w wywieraniu wplywu na innych", value: 20, intensity: "troche" }
+        ]
+    },
+    {
+        name: "ogien", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia ognia (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia ognia", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "powietrze", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia powietrza (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia powietrza", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "ziemia", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia ziemi (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia ziemi", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "woda", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia wody (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia wody", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "zycie", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia zycia (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia zycia", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "smierc", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia mroku (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia mroku", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "przemiana", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia przemiany (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia przemiany", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "mistycyzm", cost: 30, description: "podnosi nieznacznie umiejetnosc w mistycyzmie (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w mistycyzmie", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "zaklinanie", cost: 30, description: "podnosi nieznacznie umiejetnosc w zaklinaniu (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w zaklinaniu", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "przywolywanie", cost: 30, description: "podnosi nieznacznie umiejetnosc w magii tworzenia i przywolywania (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w magii tworzenia i przywolywania", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "iluzja", cost: 30, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia iluzji (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia iluzji", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "rozpraszanie", cost: 30, description: "podnosi nieznacznie umiejetnosc w rozpraszaniu zaklec (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w rozpraszaniu zaklec", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "czarodziejstwo", cost: 30, description: "podnosi nieznacznie umiejetnosc w znajomosci i uzywaniu magii (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w znajomosci i uzywaniu magii", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "runy", cost: 30, description: "podnosi nieznacznie umiejetnosc w pisaniu i uzywaniu run (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w pisaniu i uzywaniu run", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "koncentracja", cost: 30, description: "podnosi nieznacznie umiejetnosc w koncentrowaniu swoich magicznych zdolnosci (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "waleczny spokoj", cost: 30, description: "podnosi troche umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki (20)", effects: [
+            { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki", value: 20, intensity: "troche" }
+        ]
+    },
+    {
+        name: "wojownik", cost: 50, description: "pozwala trenowac umiejetnosci walki wszystkimi bronmi na poprawnie (60), pozwala trenowac umiejetnosc w skutecznym uzywaniu tarczy na znosnie (45), pozwala trenowac umiejetnosc w parowaniu ciosow przeciwnika na znosnie (45) oraz pozwala trenowac umiejetnosc w unikaniu ciosow przeciwnika na znosnie (45)", effects: [
+            { type: "special", description: "pozwala trenowac umiejetnosci walki wszystkimi bronmi na poprawnie", value: 60 },
+            { type: "special", description: "pozwala trenowac umiejetnosc w skutecznym uzywaniu tarczy na znosnie", value: 45 },
+            { type: "special", description: "pozwala trenowac umiejetnosc w parowaniu ciosow przeciwnika na znosnie", value: 45 },
+            { type: "special", description: "pozwala trenowac umiejetnosc w unikaniu ciosow przeciwnika na znosnie", value: 45 }
+        ]
+    },
+    {
+        name: "mag", cost: 50, description: "pozwala trenowac umiejetnosci ze wszystkich szkol magii na powierzchownie (40), pozwala trenowac umiejetnosc w koncentrowaniu swoich magicznych zdolnosci na poprawnie (60) oraz pozwala trenowac umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki na znosnie (50)", effects: [
+            { type: "special", description: "pozwala trenowac umiejetnosci ze wszystkich szkol magii na powierzchownie", value: 40 },
+            { type: "special", description: "pozwala trenowac umiejetnosc w koncentrowaniu swoich magicznych zdolnosci na poprawnie", value: 60 },
+            { type: "special", description: "pozwala trenowac umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki na znosnie", value: 50 }
+        ]
+    },
+    {
+        name: "galop", cost: 40, description: "podnosi zauwazalnie umiejetnosc w jezdzie konnej (25), sporo umiejetnosc w walce z konskiego grzbietu (30) oraz nieznacznie umiejetnosci walki wszystkimi bronmi (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w jezdzie konnej", value: 25, intensity: "zauwazalnie" },
+            { type: "increase", stat: "umiejetnosc w walce z konskiego grzbietu", value: 30, intensity: "sporo" },
+            { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "mikstura", cost: 40, description: "podnosi troche umiejetnosc w warzeniu i rozpoznawaniu mikstur (20), troche umiejetnosc w znajdowaniu i rozpoznawaniu ziol (20) oraz nieznacznie umiejetnosc w poslugiwaniu sie magia przemiany (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w warzeniu i rozpoznawaniu mikstur", value: 20, intensity: "troche" },
+            { type: "increase", stat: "umiejetnosc w znajdowaniu i rozpoznawaniu ziol", value: 20, intensity: "troche" },
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia przemiany", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "berserker", cost: 40, description: "podnosi troche umiejetnosci walki wszystkimi bronmi (20) oraz troche umiejetnosc w walce bez broni (20) natomiast obniza nieznacznie umiejetnosc w unikaniu ciosow przeciwnika (-10), nieznacznie umiejetnosc w parowaniu ciosow przeciwnika (-10), nieznacznie umiejetnosc w skutecznym uzywaniu tarczy (-10) oraz minimalnie wytrzymalosc (-10)", effects: [
+            { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 20, intensity: "troche" },
+            { type: "increase", stat: "umiejetnosc w walce bez broni", value: 20, intensity: "troche" },
+            { type: "decrease", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: -10, intensity: "nieznacznie" },
+            { type: "decrease", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: -10, intensity: "nieznacznie" },
+            { type: "decrease", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: -10, intensity: "nieznacznie" },
+            { type: "decrease", stat: "wytrzymalosc", value: -10, intensity: "minimalnie" }
+        ]
+    },
+    {
+        name: "barbarzynca", cost: 40, description: "podnosi nieco umiejetnosci walki wszystkimi bronmi (15), nieco umiejetnosc w walce bez broni (15), minimalnie umiejetnosc w unikaniu ciosow przeciwnika (5), minimalnie umiejetnosc w parowaniu ciosow przeciwnika (5) oraz minimalnie umiejetnosc w skutecznym uzywaniu tarczy (5) ponadto blokuje uzywanie jakiekolwiek magii", effects: [
+            { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 15, intensity: "nieco" },
+            { type: "increase", stat: "umiejetnosc w walce bez broni", value: 15, intensity: "nieco" },
+            { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 5, intensity: "minimalnie" },
+            { type: "special", description: "blokuje uzywanie jakiekolwiek magii" }
+        ]
+    },
+    {
+        name: "mag bojowy", cost: 40, description: "podnosi minimalnie umiejetnosci walki wszystkimi bronmi (5), nieco umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki (15), minimalnie umiejetnosc w unikaniu ciosow przeciwnika (5), minimalnie umiejetnosc w parowaniu ciosow przeciwnika (5) oraz minimalnie umiejetnosc w skutecznym uzywaniu tarczy (5) natomiast obniza nieco wplyw wagi zbroi na czarowanie (-25)", effects: [
+            { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki", value: 15, intensity: "nieco" },
+            { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 5, intensity: "minimalnie" },
+            { type: "decrease", stat: "wplyw wagi zbroi na czarowanie", value: -25, intensity: "nieco" }
+        ]
+    },
+    {
+        name: "tarczownik", cost: 40, description: "podnosi nieco umiejetnosc w unikaniu ciosow przeciwnika (15), nieco umiejetnosc w parowaniu ciosow przeciwnika (15), nieco umiejetnosc w skutecznym uzywaniu tarczy (15), nieco umiejetnosc w walce w szyku (15) oraz nieco maksymalna kondycje (1000) natomiast obniza minimalnie umiejetnosci walki wszystkimi bronmi (-5) oraz minimalnie umiejetnosc w walce bez broni (-5)", effects: [
+            { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 15, intensity: "nieco" },
+            { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 15, intensity: "nieco" },
+            { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 15, intensity: "nieco" },
+            { type: "increase", stat: "umiejetnosc w walce w szyku", value: 15, intensity: "nieco" },
+            { type: "increase", stat: "maksymalna kondycje", value: 1000, intensity: "nieco" },
+            { type: "decrease", stat: "umiejetnosci walki wszystkimi bronmi", value: -5, intensity: "minimalnie" },
+            { type: "decrease", stat: "umiejetnosc w walce bez broni", value: -5, intensity: "minimalnie" }
+        ]
+    },
+    {
+        name: "celny", cost: 40, description: "podnosi nieznacznie umiejetnosc w walce dwiema bronmi jednoczesnie (10) oraz nieznacznie ilosc obrazen ktore pomijaja zbroje (20)", effects: [
+            { type: "increase", stat: "umiejetnosc w walce dwiema bronmi jednoczesnie", value: 10, intensity: "nieznacznie" },
+            { type: "increase", stat: "ilosc obrazen ktore pomijaja zbroje", value: 20, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "szybki", cost: 40, description: "podnosi minimalnie zrecznosc (10) oraz nieznacznie szybkosc wyprowadzanych atakow (20) natomiast obniza minimalnie sile (-10) oraz nieznacznie umiejetnosc w wyczuwaniu slabosci wroga (-10)", effects: [
+            { type: "increase", stat: "zrecznosc", value: 10, intensity: "minimalnie" },
+            { type: "increase", stat: "szybkosc wyprowadzanych atakow", value: 20, intensity: "nieznacznie" },
+            { type: "decrease", stat: "sile", value: -10, intensity: "minimalnie" },
+            { type: "decrease", stat: "umiejetnosc w wyczuwaniu slabosci wroga", value: -10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "silacz", cost: 40, description: "podnosi minimalnie umiejetnosc w walce dwiema bronmi jednoczesnie (5) oraz nieznacznie regeneracje zmeczenia (15) ponadto pozwala dobywac dwureczne bronie jedna reka (2)", effects: [
+            { type: "increase", stat: "umiejetnosc w walce dwiema bronmi jednoczesnie", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "regeneracje zmeczenia", value: 15, intensity: "nieznacznie" },
+            { type: "special", description: "pozwala dobywac dwureczne bronie jedna reka", value: 2 }
+        ]
+    },
+    {
+        name: "mesmer", cost: 40, description: "podnosi nieznacznie umiejetnosc w koncentrowaniu swoich magicznych zdolnosci (10), minimalnie umiejetnosci ze wszystkich szkol magii (5) oraz nieznacznie maksymalna mane (300)", effects: [
+            { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci", value: 10, intensity: "nieznacznie" },
+            { type: "increase", stat: "umiejetnosci ze wszystkich szkol magii", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "maksymalna mane", value: 300, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "specjalista", cost: 40, description: "podnosi nieznacznie ilosc wyprowadzanych atakow specjalnych (15)", effects: [
+            { type: "increase", stat: "ilosc wyprowadzanych atakow specjalnych", value: 15, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "kaplan bitewny", cost: 40, description: "podnosi minimalnie umiejetnosc w poslugiwaniu sie magia zycia (5), nieznacznie umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki (10), minimalnie umiejetnosc w unikaniu ciosow przeciwnika (5), minimalnie umiejetnosc w parowaniu ciosow przeciwnika (5) oraz minimalnie umiejetnosc w skutecznym uzywaniu tarczy (5) ponadto pozwala uzywac tarczy, parowac i unikac podczas czarowania (1)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia zycia", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w koncentrowaniu swoich magicznych zdolnosci podczas walki", value: 10, intensity: "nieznacznie" },
+            { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w parowaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 5, intensity: "minimalnie" },
+            { type: "special", description: "pozwala uzywac tarczy, parowac i unikac podczas czarowania", value: 1 }
+        ]
+    },
+    {
+        name: "zdrada", cost: 10, description: "podnosi minimalnie inteligencje (5) ponadto zamienia ze soba umiejetnosci w poslugiwaniu sie magia zycia i w poslugiwaniu sie magia mroku", effects: [
+            { type: "increase", stat: "inteligencje", value: 5, intensity: "minimalnie" },
+            { type: "special", description: "zamienia ze soba umiejetnosci w poslugiwaniu sie magia zycia i w poslugiwaniu sie magia mroku" }
+        ]
+    },
+    {
+        name: "podmiana", cost: 10, description: "podnosi minimalnie sile (5) ponadto zamienia ze soba umiejetnosci w skutecznym uzywaniu tarczy i w walce dwiema bronmi jednoczesnie", effects: [
+            { type: "increase", stat: "sile", value: 5, intensity: "minimalnie" },
+            { type: "special", description: "zamienia ze soba umiejetnosci w skutecznym uzywaniu tarczy i w walce dwiema bronmi jednoczesnie" }
+        ]
+    },
+    {
+        name: "bestia", cost: 40, description: "podnosi nieznacznie umiejetnosc w walce bez broni (10) oraz nieznacznie umiejetnosc w poslugiwaniu sie magia przemiany (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w walce bez broni", value: 10, intensity: "nieznacznie" },
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia przemiany", value: 10, intensity: "nieznacznie" }
+        ]
+    },
+    {
+        name: "wladca bestii", cost: 40, description: "podnosi nieznacznie umiejetnosc w magii tworzenia i przywolywania (10) natomiast obniza troche ilosc many potrzebna do utrzymania przywolancow (-35) ponadto pozwala przywolac jednego dodatkowego, innego niz juz wezwany przywolanca (1)", effects: [
+            { type: "increase", stat: "umiejetnosc w magii tworzenia i przywolywania", value: 10, intensity: "nieznacznie" },
+            { type: "decrease", stat: "ilosc many potrzebna do utrzymania przywolancow", value: -35, intensity: "troche" },
+            { type: "special", description: "pozwala przywolac jednego dodatkowego, innego niz juz wezwany przywolanca", value: 1 }
+        ]
+    },
+    {
+        name: "kaznodzieja", cost: 40, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia zycia (10), nieznacznie umiejetnosc w mistycyzmie (10), minimalnie madrosc (10), nieznacznie odpornosc na obrazenia magii smierci (10) oraz minimalnie sile czarow leczacych (10)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia zycia", value: 10, intensity: "nieznacznie" },
+            { type: "increase", stat: "umiejetnosc w mistycyzmie", value: 10, intensity: "nieznacznie" },
+            { type: "increase", stat: "madrosc", value: 10, intensity: "minimalnie" },
+            { type: "increase", stat: "odpornosc na obrazenia magii smierci", value: 10, intensity: "nieznacznie" },
+            { type: "increase", stat: "sile czarow leczacych", value: 10, intensity: "minimalnie" }
+        ]
+    },
+    {
+        name: "sila smoka", cost: 60, description: "laczy ducha wlasciciela z duchem pradawnego smoka", effects: [
+            { type: "special", description: "laczy ducha wlasciciela z duchem pradawnego smoka" }
+        ]
+    },
+    {
+        name: "ciezkozbrojny", cost: 40, description: "podnosi minimalnie sile (5), minimalnie umiejetnosci walki wszystkimi bronmi (5) oraz minimalnie umiejetnosc w skutecznym uzywaniu tarczy (5) natomiast obniza zauwazalnie wplyw przeciazenia na zmeczenie w walce (-50)", effects: [
+            { type: "increase", stat: "sile", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w skutecznym uzywaniu tarczy", value: 5, intensity: "minimalnie" },
+            { type: "decrease", stat: "wplyw przeciazenia na zmeczenie w walce", value: -50, intensity: "zauwazalnie" }
+        ]
+    },
+    {
+        name: "wladca ciemnosci", cost: 40, description: "podnosi nieznacznie umiejetnosc w poslugiwaniu sie magia mroku (10) natomiast obniza troche ilosc many potrzebna do utrzymania przywolancow (-35) ponadto pozwala przywolac jednego dodatkowego, innego niz juz wezwany przywolanca (1)", effects: [
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia mroku", value: 10, intensity: "nieznacznie" },
+            { type: "decrease", stat: "ilosc many potrzebna do utrzymania przywolancow", value: -35, intensity: "troche" },
+            { type: "special", description: "pozwala przywolac jednego dodatkowego, innego niz juz wezwany przywolanca", value: 1 }
+        ]
+    },
+    {
+        name: "kamiennoskory", cost: 40, description: "podnosi nieco odpornosc na obrazenia klute (18), nieco odpornosc na obrazenia ciete (18) oraz nieco odpornosc na obrazenia obuchowe (18)", effects: [
+            { type: "increase", stat: "odpornosc na obrazenia klute", value: 18, intensity: "nieco" },
+            { type: "increase", stat: "odpornosc na obrazenia ciete", value: 18, intensity: "nieco" },
+            { type: "increase", stat: "odpornosc na obrazenia obuchowe", value: 18, intensity: "nieco" }
+        ]
+    },
+    {
+        name: "antymagia", cost: 40, description: "podnosi zauwazalnie odpornosc na obrazenia magii powietrza (40), zauwazalnie odpornosc na obrazenia magii ziemi (40), zauwazalnie odpornosc na obrazenia magii ognia (40), zauwazalnie odpornosc na obrazenia magii wody (40), zauwazalnie odpornosc na obrazenia magii zycia (40) oraz zauwazalnie odpornosc na obrazenia magii smierci (40)", effects: [
+            { type: "increase", stat: "odpornosc na obrazenia magii powietrza", value: 40, intensity: "zauwazalnie" },
+            { type: "increase", stat: "odpornosc na obrazenia magii ziemi", value: 40, intensity: "zauwazalnie" },
+            { type: "increase", stat: "odpornosc na obrazenia magii ognia", value: 40, intensity: "zauwazalnie" },
+            { type: "increase", stat: "odpornosc na obrazenia magii wody", value: 40, intensity: "zauwazalnie" },
+            { type: "increase", stat: "odpornosc na obrazenia magii zycia", value: 40, intensity: "zauwazalnie" },
+            { type: "increase", stat: "odpornosc na obrazenia magii smierci", value: 40, intensity: "zauwazalnie" }
+        ]
+    },
+    {
+        name: "lekkozbrojny", cost: 40, description: "podnosi minimalnie zrecznosc (5), minimalnie umiejetnosci walki wszystkimi bronmi (5), minimalnie umiejetnosc w unikaniu ciosow przeciwnika (5), ogromnie wplyw przeciazenia na zmeczenie w walce (100), bardzo ilosc przeciwnikow z ktorymi mozemy walczyc bez utraty sprawnosci (4) oraz minimalnie ilosc obrazen ktore pomijaja zbroje (10)", effects: [
+            { type: "increase", stat: "zrecznosc", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosci walki wszystkimi bronmi", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "umiejetnosc w unikaniu ciosow przeciwnika", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "wplyw przeciazenia na zmeczenie w walce", value: 100, intensity: "ogromnie" },
+            { type: "increase", stat: "ilosc przeciwnikow z ktorymi mozemy walczyc bez utraty sprawnosci", value: 4, intensity: "bardzo" },
+            { type: "increase", stat: "ilosc obrazen ktore pomijaja zbroje", value: 10, intensity: "minimalnie" }
+        ]
+    },
+    {
+        name: "mistrz harmonii", cost: 40, description: "podnosi minimalnie sile czarow wzmacniajacych (5) oraz minimalnie sile czarow oslabiajacych (5) natomiast obniza nieco ilosc many potrzebna do utrzymania aur (-30) ponadto pozwala utrzymywac jedna dodatkowa aure (1)", effects: [
+            { type: "increase", stat: "sile czarow wzmacniajacych", value: 5, intensity: "minimalnie" },
+            { type: "increase", stat: "sile czarow oslabiajacych", value: 5, intensity: "minimalnie" },
+            { type: "decrease", stat: "ilosc many potrzebna do utrzymania aur", value: -30, intensity: "nieco" },
+            { type: "special", description: "pozwala utrzymywac jedna dodatkowa aure", value: 1 }
+        ]
+    },
+    {
+        name: "przewrotnosc", cost: 10, description: "podnosi minimalnie zrecznosc (5) ponadto zamienia ze soba umiejetnosci w parowaniu ciosow przeciwnika i w unikaniu ciosow przeciwnika", effects: [
+            { type: "increase", stat: "zrecznosc", value: 5, intensity: "minimalnie" },
+            { type: "special", description: "zamienia ze soba umiejetnosci w parowaniu ciosow przeciwnika i w unikaniu ciosow przeciwnika" }
+        ]
+    },
+    {
+        name: "wszechstronny", cost: 40, description: "podnosi zauwazalnie wielkosc listy dozwolonych czarow (5), nieznacznie umiejetnosc w poslugiwaniu sie magia ognia (8), nieznacznie umiejetnosc w poslugiwaniu sie magia wody (8), nieznacznie umiejetnosc w poslugiwaniu sie magia ziemi (8) oraz nieznacznie umiejetnosc w poslugiwaniu sie magia powietrza (8) natomiast obniza troche koszt czarow (-40), nieco szybkosc odnawiania czarow (-100) oraz minimalnie szybkosc czarowania (-10)", effects: [
+            { type: "increase", stat: "wielkosc listy dozwolonych czarow", value: 5, intensity: "zauwazalnie" },
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia ognia", value: 8, intensity: "nieznacznie" },
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia wody", value: 8, intensity: "nieznacznie" },
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia ziemi", value: 8, intensity: "nieznacznie" },
+            { type: "increase", stat: "umiejetnosc w poslugiwaniu sie magia powietrza", value: 8, intensity: "nieznacznie" },
+            { type: "decrease", stat: "koszt czarow", value: -40, intensity: "troche" },
+            { type: "decrease", stat: "szybkosc odnawiania czarow", value: -100, intensity: "nieco" },
+            { type: "decrease", stat: "szybkosc czarowania", value: -10, intensity: "minimalnie" }
+        ]
+    },
+    {
+        name: "wampir", cost: 40, description: "podnosi troche ilosc zycia wykradanego przy atakach (40) ponadto sprawia ze nie mozesz byc magicznie uleczony (1)", effects: [
+            { type: "increase", stat: "ilosc zycia wykradanego przy atakach", value: 40, intensity: "troche" },
+            { type: "special", description: "sprawia ze nie mozesz byc magicznie uleczony", value: 1 }
+        ]
+    },
+    {
+        name: "sama magia", cost: 40, description: "podnosi minimalnie szybkosc odnawiania czarow (20) oraz minimalnie szybkosc czarowania (20) natomiast obniza nieznacznie koszt czarow (-15), ogromnie szybkosc wyprowadzanych atakow (-1000) oraz ogromnie ilosc wyprowadzanych atakow specjalnych (-1000)", effects: [
+            { type: "increase", stat: "szybkosc odnawiania czarow", value: 20, intensity: "minimalnie" },
+            { type: "increase", stat: "szybkosc czarowania", value: 20, intensity: "minimalnie" },
+            { type: "decrease", stat: "koszt czarow", value: -15, intensity: "nieznacznie" },
+            { type: "decrease", stat: "szybkosc wyprowadzanych atakow", value: -1000, intensity: "ogromnie" },
+            { type: "decrease", stat: "ilosc wyprowadzanych atakow specjalnych", value: -1000, intensity: "ogromnie" }
+        ]
+    },
+    {
+        name: "cien", cost: 40, description: "podnosi nieznacznie ilosc obrazen ktore pomijaja odpornosci (20), nieco ilosc obrazen ktore pomijaja zbroje (30), ogromnie wplyw wagi zbroi na szybkosc walki (100) oraz ogromnie wplyw wagi zbroi na czarowanie (500) natomiast obniza nieco odpornosc na obrazenia klute (-25), nieco odpornosc na obrazenia ciete (-25), nieco odpornosc na obrazenia obuchowe (-25), nieco odpornosc na obrazenia magii powietrza (-25), nieco odpornosc na obrazenia magii ziemi (-25), nieco odpornosc na obrazenia magii ognia (-25), nieco odpornosc na obrazenia magii wody (-25), nieco odpornosc na obrazenia magii zycia (-25) oraz nieco odpornosc na obrazenia magii smierci (-25)", effects: [
+            { type: "increase", stat: "ilosc obrazen ktore pomijaja odpornosci", value: 20, intensity: "nieznacznie" },
+            { type: "increase", stat: "ilosc obrazen ktore pomijaja zbroje", value: 30, intensity: "nieco" },
+            { type: "increase", stat: "wplyw wagi zbroi na szybkosc walki", value: 100, intensity: "ogromnie" },
+            { type: "increase", stat: "wplyw wagi zbroi na czarowanie", value: 500, intensity: "ogromnie" },
+            { type: "decrease", stat: "odpornosc na obrazenia klute", value: -25, intensity: "nieco" },
+            { type: "decrease", stat: "odpornosc na obrazenia ciete", value: -25, intensity: "nieco" },
+            { type: "decrease", stat: "odpornosc na obrazenia obuchowe", value: -25, intensity: "nieco" },
+            { type: "decrease", stat: "odpornosc na obrazenia magii powietrza", value: -25, intensity: "nieco" },
+            { type: "decrease", stat: "odpornosc na obrazenia magii ziemi", value: -25, intensity: "nieco" },
+            { type: "decrease", stat: "odpornosc na obrazenia magii ognia", value: -25, intensity: "nieco" },
+            { type: "decrease", stat: "odpornosc na obrazenia magii wody", value: -25, intensity: "nieco" },
+            { type: "decrease", stat: "odpornosc na obrazenia magii zycia", value: -25, intensity: "nieco" },
+            { type: "decrease", stat: "odpornosc na obrazenia magii smierci", value: -25, intensity: "nieco" }
+        ]
+    },
+    // Dodaj więcej słów według potrzeb
+];

--- a/style.css
+++ b/style.css
@@ -1,92 +1,114 @@
+.custom-checkbox {
+    display: none;
+}
 
-        .custom-checkbox {
-            display: none;
-        }
-        .custom-checkbox + label {
-            cursor: pointer;
-            transition: all 0.3s;
-        }
-        .custom-checkbox:checked + label {
-            background-color: var(--accent-color);
-            color: white;
-        }
-        .tooltip {
-            visibility: hidden;
-            position: absolute;
-            z-index: 10;
-            opacity: 0;
-            transition: opacity 0.3s;
-            width: 280px;
-        }
-        .tooltip-trigger:hover .tooltip {
-            visibility: visible;
-            opacity: 1;
-        }
-        :root {
-            --bg-color: #f8f9fa;
-            --text-color: #212529;
-            --card-bg: #ffffff;
-            --border-color: #dee2e6;
-            --accent-color: #4f46e5;
-            --accent-hover: #4338ca;
-            --skill-bar-bg: #e9ecef;
-            --skill-bar-fill: #4f46e5;
-        }
-        .dark {
-            --bg-color: #1a202c;
-            --text-color: #f8f9fa;
-            --card-bg: #2d3748;
-            --border-color: #4a5568;
-            --accent-color: #6366f1;
-            --accent-hover: #5a67d8;
-            --skill-bar-bg: #4a5568;
-            --skill-bar-fill: #6366f1;
-        }
-        body {
-            background-color: var(--bg-color);
-            color: var(--text-color);
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .card {
-            background-color: var(--card-bg);
-            border: 1px solid var(--border-color);
-            transition: background-color 0.3s, border-color 0.3s;
-        }
-        .btn-primary {
-            background-color: var(--accent-color);
-        }
-        .btn-primary:hover {
-            background-color: var(--accent-hover);
-        }
-        .skill-bar {
-            background-color: var(--skill-bar-bg);
-        }
-        .skill-bar-fill {
-            background-color: var(--skill-bar-fill);
-        }
-        .toggle-checkbox:checked {
-            right: 0;
-            border-color: var(--accent-color);
-        }
-        .toggle-checkbox:checked + .toggle-label {
-            background-color: var(--accent-color);
-        }
-        .selected-item {
-            background-color: var(--accent-color);
-            color: white;
-        }
-		.skill-diff {
-		right: 0.5em; /* Spróbuj tej wartości jako punktu wyjścia */
-		top: -1.0em;
-		/* Możesz też spróbować użyć transformacji, aby dodatkowo przesunąć w lewo */
-		/* transform: translateX(100%); */ /* To przesunie element w prawo o jego własną szerokość */
-		}
-		.guild-section {
-		margin-bottom: 2rem; /* Większy odstęp między sekcjami gildii */
-		}
-		.dark select {
-		background-color: #2d3748; /* Użyj ciemnego koloru tła, np. takiego jak tło kart */
-		color: #f8f9fa; /* Ustaw jasny kolor tekstu dla lepszego kontrastu */
-		border-color: #4a5568; /* Dopasuj kolor obramowania do innych ciemnych elementów */
-		}
-	}
+.custom-checkbox+label {
+    cursor: pointer;
+    transition: all 0.3s;
+}
+
+.custom-checkbox:checked+label {
+    background-color: var(--accent-color);
+    color: white;
+}
+
+.tooltip {
+    visibility: hidden;
+    position: absolute;
+    z-index: 10;
+    opacity: 0;
+    transition: opacity 0.3s;
+    width: 280px;
+}
+
+.tooltip-trigger:hover .tooltip {
+    visibility: visible;
+    opacity: 1;
+}
+
+:root {
+    --bg-color: #f8f9fa;
+    --text-color: #212529;
+    --card-bg: #ffffff;
+    --border-color: #dee2e6;
+    --accent-color: #4f46e5;
+    --accent-hover: #4338ca;
+    --skill-bar-bg: #e9ecef;
+    --skill-bar-fill: #4f46e5;
+}
+
+.dark {
+    --bg-color: #1a202c;
+    --text-color: #f8f9fa;
+    --card-bg: #2d3748;
+    --border-color: #4a5568;
+    --accent-color: #6366f1;
+    --accent-hover: #5a67d8;
+    --skill-bar-bg: #4a5568;
+    --skill-bar-fill: #6366f1;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    transition: background-color 0.3s, color 0.3s;
+}
+
+.card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    transition: background-color 0.3s, border-color 0.3s;
+}
+
+.btn-primary {
+    background-color: var(--accent-color);
+}
+
+.btn-primary:hover {
+    background-color: var(--accent-hover);
+}
+
+.skill-bar {
+    background-color: var(--skill-bar-bg);
+}
+
+.skill-bar-fill {
+    background-color: var(--skill-bar-fill);
+}
+
+.toggle-checkbox:checked {
+    right: 0;
+    border-color: var(--accent-color);
+}
+
+.toggle-checkbox:checked+.toggle-label {
+    background-color: var(--accent-color);
+}
+
+.selected-item {
+    background-color: var(--accent-color);
+    color: white;
+}
+
+.skill-diff {
+    right: 0.5em;
+    /* Spróbuj tej wartości jako punktu wyjścia */
+    top: -1.0em;
+    /* Możesz też spróbować użyć transformacji, aby dodatkowo przesunąć w lewo */
+    /* transform: translateX(100%); */
+    /* To przesunie element w prawo o jego własną szerokość */
+}
+
+.guild-section {
+    margin-bottom: 2rem;
+    /* Większy odstęp między sekcjami gildii */
+}
+
+.dark select {
+    background-color: #2d3748;
+    /* Użyj ciemnego koloru tła, np. takiego jak tło kart */
+    color: #f8f9fa;
+    /* Ustaw jasny kolor tekstu dla lepszego kontrastu */
+    border-color: #4a5568;
+    /* Dopasuj kolor obramowania do innych ciemnych elementów */
+}


### PR DESCRIPTION
Poprawia czytelność interfejsu użytkownika, pokazując aktualny stan przełącznika.

Fix: Popraw działanie efektów słów modyfikujących umiejętności

- Zrefaktoryzowano `calculateModifiedSkills` w celu poprawnego mapowania opisowych nazw statystyk (np. "umiejetnosc w...") na rzeczywiste klucze umiejętności (np. "mistycyzm").
- Rozwiązano problem, przez który słowa takie jak "kaznodzieja", "mistycyzm", "iluzja" i inne nie dodawały bonusów do umiejętności.
- Uwzględniono zmianę nazwy `koncentracje` na `koncentracja`.
